### PR TITLE
add slingfeature project

### DIFF
--- a/sling/core/.parent/pom.xml
+++ b/sling/core/.parent/pom.xml
@@ -141,6 +141,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>slingstart-maven-plugin</artifactId>
+                    <version>1.3.6</version>
+                </plugin>
+
+                <plugin>
                     <groupId>com.citytechinc.maven.plugins</groupId>
                     <artifactId>osgi-bundle-status-maven-plugin</artifactId>
                     <version>1.3.1</version>

--- a/sling/core/pom.xml
+++ b/sling/core/pom.xml
@@ -14,6 +14,7 @@
 		<module>jslibs</module>
 		<module>commons</module>
 		<module>console</module>
+		<module>slingfeature</module>
 	</modules>
 
 </project>

--- a/sling/core/slingfeature/pom.xml
+++ b/sling/core/slingfeature/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.composum.sling.core</groupId>
+        <artifactId>composum-sling-core-parent</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+        <relativePath>../.parent</relativePath>
+    </parent>
+
+    <artifactId>composum-sling-core-slingfeature</artifactId>
+    <packaging>slingfeature</packaging>
+
+    <name>Composum Core Sling Feature</name>
+    <description>Sling feature for easy integration of Composum Console in slingstart projects.</description>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>slingstart-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <usePomDependencies>true</usePomDependencies>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+
+        <!-- Composum -->
+        <dependency>
+            <groupId>com.composum.sling.core</groupId>
+            <artifactId>composum-sling-core-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.composum.sling.core</groupId>
+            <artifactId>composum-sling-core-jslibs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.composum.sling.core</groupId>
+            <artifactId>composum-sling-core-console</artifactId>
+        </dependency>
+        
+        <!-- Commons Lang -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <!-- Overwrite version from parent pom because version 3.0 creates problems in sling 8 because it 
+                 has same symbolic name as commons-lang2 and overwrites this version, though not backward compatible. -->
+            <version>3.3.2</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/sling/core/slingfeature/src/main/provisioning/composum-console.txt
+++ b/sling/core/slingfeature/src/main/provisioning/composum-console.txt
@@ -1,0 +1,7 @@
+[feature name=composum-console]
+
+[artifacts startLevel=20]
+  org.apache.commons/commons-lang3
+  com.composum.sling.core/composum-sling-core-commons
+  com.composum.sling.core/composum-sling-core-jslibs
+  com.composum.sling.core/composum-sling-core-console


### PR DESCRIPTION
with this feature it is possible to include composum console in a slingstart provisioning file with one line:

```
[artifacts]
  com.composum.sling.core/composum-sling-core-slingfeature/1.4.0-SNAPSHOT/slingfeature
```
this fixes #4 