### PR TITLE
Included "org.apache.commons.lang3.*" to maven-bundle-plugin's...

### DIFF
--- a/sling/core/commons/pom.xml
+++ b/sling/core/commons/pom.xml
@@ -50,7 +50,8 @@
                             com.composum.sling.core.*,
                             com.composum.sling.cpnl.*,
                             com.google.gson.*,
-                            javax.inject.*
+                            javax.inject.*,
+                            org.apache.commons.lang3.*
                         </Export-Package>
                         <Embed-Dependency>
                             *;scope=compile|runtime


### PR DESCRIPTION
…<Export-Package> list. Without this the bundles are not getting Active. They show an error message of "org.apache.commons.lang3, version [3.0,4).. cannot be resolved."

```xml
     <groupId>org.apache.felix</groupId>
          <artifactId>maven-bundle-plugin</artifactId>
          ...
          <Export-Package>
              com.composum.sling.clientlibs.*,
             com.composum.sling.core.*,
             com.composum.sling.cpnl.*,
             com.google.gson.*,
             javax.inject.*,
             org.apache.commons.lang3.*
          </Export-Package>
```