### PR TITLE
#73 fix for the fix: set force to ‚true‘ by default for the ‚service' operation

### DIFF
--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
@@ -749,7 +749,7 @@ public class PackageServlet extends AbstractServiceServlet {
                 RequestParameter file = parameters.getValue(AbstractServiceServlet.PARAM_FILE);
                 if (file != null) {
                     InputStream input = file.getInputStream();
-                    boolean force = RequestUtil.getParameter(request, PARAM_FORCE, false);
+                    boolean force = RequestUtil.getParameter(request, PARAM_FORCE, true);
 
                     JcrPackageManager manager = PackageUtil.createPackageManager(request);
                     JcrPackage jcrPackage = manager.upload(input, force);


### PR DESCRIPTION
for auto install during maven build the 'force' flag must be set to 'true' by default - for the 'service' operation