### PR TITLE
#105 administrative whitelist configuration

### DIFF
--- a/sling/core/corecfg/pom.xml
+++ b/sling/core/corecfg/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.composum.sling.core</groupId>
+        <artifactId>composum-sling-core-parent</artifactId>
+        <version>1.9.0-SNAPSHOT</version>
+        <relativePath>../.parent</relativePath>
+    </parent>
+
+    <artifactId>composum-sling-core-config</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Composum Core Configuration</name>
+    <description>the set of necessary OSGi configuration fragments</description>
+
+    <properties>
+        <bundle.name>com.composum.core.config</bundle.name>
+    </properties>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Category>${bundle.category}</Bundle-Category>
+                        <Bundle-SymbolicName>${bundle.name}</Bundle-SymbolicName>
+                        <Include-Resource>
+                            {maven-resources}
+                        </Include-Resource>
+                        <Sling-Initial-Content>
+                            root/libs/composum/nodes/install;path:=/libs/composum/nodes/install;overwrite:=true
+                        </Sling-Initial-Content>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+    <profiles>
+
+        <profile>
+            <id>installBundle</id>
+            <activation>
+                <property>
+                    <name>deploy.bundle</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>maven-sling-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-bundle</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>installPackage</id>
+        </profile>
+        <profile>
+            <id>installTestContent</id>
+        </profile>
+
+    </profiles>
+
+</project>
+

--- a/sling/core/corecfg/src/main/resources/root/libs/composum/nodes/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-composum_core.config
+++ b/sling/core/corecfg/src/main/resources/root/libs/composum/nodes/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-composum_core.config
@@ -1,0 +1,6 @@
+whitelist.name="composum_core"
+whitelist.bundles=[
+      "com.composum.core.commons",
+      "com.composum.core.pckgmgr",
+      "com.composum.core.pckginstall"
+]

--- a/sling/core/corepckg/pom.xml
+++ b/sling/core/corepckg/pom.xml
@@ -93,6 +93,11 @@
                             <artifactId>composum-sling-user-management</artifactId>
                             <target>/libs/composum/nodes/install</target>
                         </embedded>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>composum-sling-core-config</artifactId>
+                            <target>/libs/composum/nodes/install</target>
+                        </embedded>
                     </embeddeds>
 
                 </configuration>
@@ -127,6 +132,11 @@
             <artifactId>composum-sling-core-jslibs</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>composum-sling-core-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
     </dependencies>
     <profiles>
@@ -136,6 +146,31 @@
         </profile>
         <profile>
             <id>installPackage</id>
+            <activation>
+                <property>
+                    <name>deploy.package</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+
+                    <plugin>
+                        <groupId>com.day.jcr.vault</groupId>
+                        <artifactId>content-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install-content-package</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>installTestContent</id>

--- a/sling/core/pom-ui.xml
+++ b/sling/core/pom-ui.xml
@@ -22,6 +22,7 @@
 		<module>pckgmgr</module>
 		<module>usermgnt</module>
 		<module>slingfeature</module>
+		<module>corecfg</module>
 		<module>corepckg</module>
 	</modules>
 

--- a/sling/core/pom.xml
+++ b/sling/core/pom.xml
@@ -24,6 +24,7 @@
 		<module>pckgmgr</module>
 		<module>usermgnt</module>
 		<module>slingfeature</module>
+		<module>corecfg</module>
 		<module>corepckg</module>
 
 		<!-- Test modules - no deployed code contained -->

--- a/sling/core/slingfeature/src/main/provisioning/composum-console.txt
+++ b/sling/core/slingfeature/src/main/provisioning/composum-console.txt
@@ -7,3 +7,12 @@
   com.composum.sling.core/composum-sling-core-console
   com.composum.sling.core/composum-sling-package-manager
   com.composum.sling.core/composum-sling-user-management
+
+[configurations]
+  org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-composum_core
+    whitelist.name="composum_core"
+    whitelist.bundles=[
+      "com.composum.core.commons",
+      "com.composum.core.pckgmgr",
+      "com.composum.core.pckginstall"
+    ]


### PR DESCRIPTION
The Core package is implemented to provide a wide range of Sling and AEM versions. Therefore the necessary administrative logins are currently not transformed into service users based logins. But i think we will do this in one of the next releases.
Unit then we have whitelist the bundles - configuration added now.