### PR TITLE
fix browser for /mnt/override and /mnt/overlay

### DIFF
--- a/sling/core/commons/src/main/java/com/composum/sling/core/filter/ResourceFilter.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/filter/ResourceFilter.java
@@ -278,18 +278,8 @@ public interface ResourceFilter {
          */
         @Override
         public boolean accept(Resource resource) {
-            if (resource != null) {
-                Node node = resource.adaptTo(Node.class);
-                if (node != null) {
-                    NodeType type;
-                    try {
-                        type = node.getPrimaryNodeType();
-                        return filter.accept(type.getName());
-                    } catch (RepositoryException e) {
-                        // ok, its possible that primary type is not available (synthetic resource)
-                    }
-                }
-            }
+            String primaryType = ResourceUtil.getPrimaryType(resource);
+            if (StringUtils.isNotBlank(primaryType)) return filter.accept(primaryType);
             return false;
         }
 

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -178,7 +178,7 @@ public class SourceModel extends ConsoleSlingBean {
     }
 
     public String getPrimaryType() {
-        return ResourceUtil.getPrimaryType(resource);
+        return StringUtils.defaultString(ResourceUtil.getPrimaryType(resource));
     }
 
     public List<Property> getPropertyList() {

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -178,12 +178,7 @@ public class SourceModel extends ConsoleSlingBean {
     }
 
     public String getPrimaryType() {
-        try {
-            return resource.adaptTo(Node.class).getPrimaryNodeType().getName();
-        } catch (RepositoryException rex) {
-            LOG.error(rex.getMessage(), rex);
-        }
-        return "";
+        return ResourceUtil.getPrimaryType(resource);
     }
 
     public List<Property> getPropertyList() {


### PR DESCRIPTION
Bugfix: use fixed ResourceUtil.getPrimaryType methods for determining the primary type in ResourceFilter and SourceModel to make the browser compatible with /mnt/override and /mnt/overlay