### PR TITLE
Replace obsolete PackageUtil.createPackageManager

### DIFF
--- a/sling/core/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/dialogs.js
+++ b/sling/core/commons/src/main/resources/root/libs/composum/nodes/commons/components/js/dialogs.js
@@ -467,7 +467,11 @@
                             if (_.isObject(result) && _.isObject(result.response)) {
                                 var response = result.response;
                                 var messages = result.messages;
-                                core.messages(response.level, response.text, messages);
+                                if (_.isArray(messages) && messages.length > 0) {
+                                    core.messages(response.level, response.text, messages);
+                                } else {
+                                    core.alert(response.level, response.title, response.text);
+                                }
                             }
                         }, this)
                     );

--- a/sling/core/pckginstall/src/main/java/com/composum/sling/core/pckginstall/PackageTransformer.java
+++ b/sling/core/pckginstall/src/main/java/com/composum/sling/core/pckginstall/PackageTransformer.java
@@ -2,9 +2,11 @@ package com.composum.sling.core.pckginstall;
 
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.jackrabbit.vault.packaging.PackagingService;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
@@ -41,6 +43,9 @@ public class PackageTransformer implements ResourceTransformer, InstallTaskFacto
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private BundleContext bundleContext;
+
+    @Reference
+    private Packaging packaging;
 
     @Activate
     private void activate(final BundleContext bundleContext) {
@@ -119,7 +124,7 @@ public class PackageTransformer implements ResourceTransformer, InstallTaskFacto
                 final Method loginAdministrative = repository.getClass().getMethod("loginAdministrative", String.class);
                 final Object invoke = loginAdministrative.invoke(repository, (Object) null);
                 final Session session = (Session) invoke;
-                final JcrPackageManager packageManager = PackagingService.getPackageManager(session);
+                final JcrPackageManager packageManager = packaging.getPackageManager(session);
                 final TaskResource resource = getResource();
                 final InputStream inputStream = resource.getInputStream();
                 logger.info("package upload - {}", resource.getEntityId());

--- a/sling/core/pckgmgr/pom.xml
+++ b/sling/core/pckgmgr/pom.xml
@@ -55,6 +55,7 @@
                             org.apache.jackrabbit.vault.*;version="[2.4.0,4)",
                             org.apache.sling.event.jobs.consumer.*;version="[1.1,3)",
                             org.apache.sling.event.jobs.*;version="[1.3,3)",
+                            !javax.annotation,
                             *
                         </Import-Package>
                         <Export-Package>
@@ -181,6 +182,11 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
 
     </dependencies>
     <profiles>

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageJobExecutor.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageJobExecutor.java
@@ -8,12 +8,14 @@ import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.io.ImportOptions;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.apache.jackrabbit.vault.packaging.PackageException;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.jackrabbit.vault.packaging.PackagingService;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -87,6 +89,8 @@ public class PackageJobExecutor extends AbstractJobExecutor<String> {
 
     protected final Lock lock = new ReentrantLock(true);
 
+    @Reference
+    private Packaging packaging;
 
     @Override
     @Activate
@@ -130,7 +134,7 @@ public class PackageJobExecutor extends AbstractJobExecutor<String> {
         public String call() throws Exception {
             lock.lock();
             try {
-                JcrPackageManager manager = PackagingService.getPackageManager(session);
+                JcrPackageManager manager = packaging.getPackageManager(session);
                 JcrPackage jcrPckg = getJcrPackage(job, manager);
                 String operation = (String) job.getProperty("operation");
                 if (StringUtils.isNotBlank(operation)) {

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.apache.jackrabbit.vault.packaging.PackageException;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
@@ -102,6 +103,9 @@ public class PackageServlet extends AbstractServiceServlet {
 
     @Reference
     private JobManager jobManager;
+
+    @Reference
+    private Packaging packaging;
 
     //
     // Servlet operations
@@ -821,7 +825,7 @@ public class PackageServlet extends AbstractServiceServlet {
                     InputStream input = file.getInputStream();
                     boolean force = RequestUtil.getParameter(request, PARAM_FORCE, true);
 
-                    JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                    JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                     JcrPackage jcrPackage = manager.upload(input, force);
 
                     installPackage(request, response, manager, jcrPackage);

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
@@ -208,7 +208,8 @@ public class PackageServlet extends AbstractServiceServlet {
             Resource resource = null;
             try {
                 String path = PackageUtil.getPath(request);
-                resource = PackageUtil.getResource(request, path);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
+                resource = PackageUtil.getResource(manager, request, path);
             } catch (RepositoryException rex) {
                 LOG.error(rex.getMessage(), rex);
             }
@@ -226,7 +227,8 @@ public class PackageServlet extends AbstractServiceServlet {
         public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
             ResourceHandle resource)
             throws RepositoryException, IOException {
-            List<JcrPackage> jcrPackages = PackageUtil.createPackageManager(request).listPackages();
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
+            List<JcrPackage> jcrPackages = manager.listPackages();
             JsonWriter writer = ResponseUtil.getJsonWriter(response);
             writer.beginArray();
             for (JcrPackage jcrPackage : jcrPackages) {
@@ -243,7 +245,8 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
+            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(manager, request);
 
             JsonWriter writer = ResponseUtil.getJsonWriter(response);
             treeNode.sort();
@@ -269,7 +272,7 @@ public class PackageServlet extends AbstractServiceServlet {
 
             if (suffix.length() > 1) {
 
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
 
                 ResourceResolver resolver = request.getResourceResolver();
                 String rootPath = manager.getPackageRoot().getPath();
@@ -318,7 +321,7 @@ public class PackageServlet extends AbstractServiceServlet {
             String name = request.getParameter(PARAM_NAME);
             String version = request.getParameter(PARAM_VERSION);
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = manager.create(group, name, version);
 
             JsonWriter writer = ResponseUtil.getJsonWriter(response);
@@ -358,7 +361,7 @@ public class PackageServlet extends AbstractServiceServlet {
 
             try {
 
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                 JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
 
                 if (jcrPackage != null) {
@@ -433,7 +436,7 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
 
             if (jcrPackage != null) {
@@ -453,7 +456,7 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
 
             if (jcrPackage != null) {
@@ -503,7 +506,7 @@ public class PackageServlet extends AbstractServiceServlet {
                 InputStream input = file.getInputStream();
                 boolean force = RequestUtil.getParameter(request, PARAM_FORCE, false);
 
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                 JcrPackage jcrPackage = manager.upload(input, force);
 
                 JsonWriter writer = ResponseUtil.getJsonWriter(response);
@@ -523,7 +526,7 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
 
             installPackage(request, response, manager, jcrPackage);
@@ -575,7 +578,7 @@ public class PackageServlet extends AbstractServiceServlet {
             ResourceHandle resource)
             throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
 
             uninstallPackage(request, response, manager, jcrPackage);
@@ -654,7 +657,7 @@ public class PackageServlet extends AbstractServiceServlet {
 
             @Override
             void doCommand(SlingHttpServletRequest request, SlingHttpServletResponse response, RequestParameterMap parameters) throws RepositoryException, IOException {
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                 final List<JcrPackage> jcrPackages = manager.listPackages();
                 response.setStatus(HttpServletResponse.SC_OK);
                 try (Writer writer = response.getWriter()) {
@@ -681,7 +684,7 @@ public class PackageServlet extends AbstractServiceServlet {
             void doCommand(SlingHttpServletRequest request, SlingHttpServletResponse response, RequestParameterMap parameters) throws RepositoryException, IOException {
                 String name = getName(parameters);
                 String group = getGroup(parameters);
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                 final List<JcrPackage> jcrPackages = manager.listPackages();
                 boolean found = false;
                 for (JcrPackage jcrPackage : jcrPackages) {
@@ -725,7 +728,7 @@ public class PackageServlet extends AbstractServiceServlet {
                 Session session = resolver.adaptTo(Session.class);
                 String name = getName(parameters);
                 String group = getGroup(parameters);
-                JcrPackageManager manager = PackageUtil.createPackageManager(request);
+                JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
                 final JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, group, name);
                 if (jcrPackage != null) {
                     String path = jcrPackage.getNode().getPath();
@@ -893,7 +896,7 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
             Session session = RequestUtil.getSession(request);
 
@@ -911,7 +914,7 @@ public class PackageServlet extends AbstractServiceServlet {
                          ResourceHandle resource)
                 throws RepositoryException, IOException {
 
-            JcrPackageManager manager = PackageUtil.createPackageManager(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(packaging, request);
             JcrPackage jcrPackage = PackageUtil.getJcrPackage(manager, resource);
             Session session = RequestUtil.getSession(request);
 
@@ -965,7 +968,7 @@ public class PackageServlet extends AbstractServiceServlet {
                 throws RepositoryException {
             this.request = request;
 
-            manager = PackageUtil.createPackageManager(request);
+            manager = PackageUtil.getPackageManager(packaging, request);
             jcrPackage = PackageUtil.getJcrPackage(manager, resource);
             definition = jcrPackage.getDefinition();
 

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
@@ -14,6 +14,7 @@ import org.apache.jackrabbit.vault.fs.config.MetaInf;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.jackrabbit.vault.packaging.PackagingService;
 import org.apache.jackrabbit.vault.util.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -77,12 +78,34 @@ public class PackageUtil {
         group, jcrpckg
     }
 
+    /**
+     * Don't use this but org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session) or {@link #getPackageManager(Packaging, SlingHttpServletRequest)} since
+     * this calls {@link PackagingService#getPackageManager(Session)} which has been depreciated
+     * @deprecated use org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session)
+     * @see org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session) or
+     */
     public static JcrPackageManager createPackageManager(SlingHttpServletRequest request)
             throws RepositoryException {
         ResourceResolver resolver = request.getResourceResolver();
         Session session = resolver.adaptTo(Session.class);
         if (session != null) {
             return PackagingService.getPackageManager(session);
+        } else {
+            throw new RepositoryException("can't adapt resolver to session");
+        }
+    }
+
+    /**
+     * Retrieves a package manager for the JCR session.
+     *
+     * @throws RepositoryException if there is no JCR session
+     */
+    public static JcrPackageManager getPackageManager(Packaging packaging, SlingHttpServletRequest request)
+            throws RepositoryException {
+        ResourceResolver resolver = request.getResourceResolver();
+        Session session = resolver.adaptTo(Session.class);
+        if (session != null) {
+            return packaging.getPackageManager(session);
         } else {
             throw new RepositoryException("can't adapt resolver to session");
         }

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
@@ -15,7 +15,6 @@ import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.apache.jackrabbit.vault.packaging.Packaging;
-import org.apache.jackrabbit.vault.packaging.PackagingService;
 import org.apache.jackrabbit.vault.util.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
@@ -79,36 +78,12 @@ public class PackageUtil {
     }
 
     /**
-     * Don't use this but org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session) or {@link #getPackageManager(Packaging, SlingHttpServletRequest)} since
-     * this calls {@link PackagingService#getPackageManager(Session)} which has been depreciated
-     * @deprecated use org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session)
-     * @see org.apache.jackrabbit.vault.packaging.Packaging#getPackageManager(javax.jcr.Session) or
-     */
-    public static JcrPackageManager createPackageManager(SlingHttpServletRequest request)
-            throws RepositoryException {
-        ResourceResolver resolver = request.getResourceResolver();
-        Session session = resolver.adaptTo(Session.class);
-        if (session != null) {
-            return PackagingService.getPackageManager(session);
-        } else {
-            throw new RepositoryException("can't adapt resolver to session");
-        }
-    }
-
-    /**
      * Retrieves a package manager for the JCR session.
-     *
-     * @throws RepositoryException if there is no JCR session
      */
-    public static JcrPackageManager getPackageManager(Packaging packaging, SlingHttpServletRequest request)
-            throws RepositoryException {
+    public static JcrPackageManager getPackageManager(Packaging packaging, SlingHttpServletRequest request) {
         ResourceResolver resolver = request.getResourceResolver();
         Session session = resolver.adaptTo(Session.class);
-        if (session != null) {
-            return packaging.getPackageManager(session);
-        } else {
-            throw new RepositoryException("can't adapt resolver to session");
-        }
+        return packaging.getPackageManager(session);
     }
 
     public static String getPath(SlingHttpServletRequest request) {
@@ -129,9 +104,8 @@ public class PackageUtil {
         return path;
     }
 
-    public static Resource getResource(SlingHttpServletRequest request, String path) throws RepositoryException {
+    public static Resource getResource(JcrPackageManager manager, SlingHttpServletRequest request, String path) throws RepositoryException {
         Resource resource = null;
-        JcrPackageManager manager = PackageUtil.createPackageManager(request);
         Node node;
         node = manager.getPackageRoot(true);
         if (node != null) {
@@ -180,11 +154,10 @@ public class PackageUtil {
         return path;
     }
 
-    public static TreeType getTreeType(SlingHttpServletRequest request, String path) {
+    public static TreeType getTreeType(JcrPackageManager manager, SlingHttpServletRequest request, String path) {
         TreeType type = group;
         try {
-            Resource resource = getResource(request, path);
-            JcrPackageManager manager = createPackageManager(request);
+            Resource resource = getResource(manager, request, path);
             JcrPackage jcrPackage = getJcrPackage(manager, resource);
             if (jcrPackage != null) {
                 type = TreeType.jcrpckg;
@@ -449,10 +422,9 @@ public class PackageUtil {
     // Tree Mapping of the flat Package list
     //
 
-    public static TreeNode getTreeNode(SlingHttpServletRequest request) throws RepositoryException {
+    public static TreeNode getTreeNode(JcrPackageManager manager, SlingHttpServletRequest request) throws RepositoryException {
 
         String path = PackageUtil.getPath(request);
-        JcrPackageManager manager = PackageUtil.createPackageManager(request);
         List<JcrPackage> jcrPackages = manager.listPackages();
 
         PackageUtil.TreeNode treeNode = new PackageUtil.TreeNode(path);

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/util/PackageUtil.java
@@ -15,6 +15,7 @@ import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.apache.jackrabbit.vault.packaging.Packaging;
+import org.apache.jackrabbit.vault.packaging.PackagingService;
 import org.apache.jackrabbit.vault.util.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestPathInfo;
@@ -24,6 +25,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.el.PropertyNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
@@ -80,10 +82,15 @@ public class PackageUtil {
     /**
      * Retrieves a package manager for the JCR session.
      */
-    public static JcrPackageManager getPackageManager(Packaging packaging, SlingHttpServletRequest request) {
+    @Nonnull
+    public static JcrPackageManager getPackageManager(@Nonnull Packaging packaging, @Nonnull SlingHttpServletRequest request) throws RepositoryException {
         ResourceResolver resolver = request.getResourceResolver();
         Session session = resolver.adaptTo(Session.class);
-        return packaging.getPackageManager(session);
+        if (session != null) {
+            return packaging.getPackageManager(session);
+        } else {
+            throw new RepositoryException("can't adapt resolver to session"); // should be impossible
+        }
     }
 
     public static String getPath(SlingHttpServletRequest request) {

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageBean.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageBean.java
@@ -281,7 +281,7 @@ public class PackageBean extends ConsoleSlingBean {
             try {
                 String path = PackageUtil.getThumbnailPath(pckgDef);
                 if (StringUtils.isNotBlank(path)) {
-                    builder.append(LinkUtil.getUrl(request, path));
+                    builder.append(LinkUtil.getUrl(getRequest(), path));
                 }
             } catch (RepositoryException rex) {
                 LOG.error(rex.getMessage(), rex);

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageBean.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageBean.java
@@ -11,6 +11,7 @@ import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
@@ -66,13 +67,13 @@ public class PackageBean extends ConsoleSlingBean {
         SlingHttpServletRequest request = context.getRequest();
         path = PackageUtil.getPath(request);
         try {
-            resource = PackageUtil.getResource(request, path);
+            pckgMgr = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
+            resource = PackageUtil.getResource(pckgMgr, request, path);
         } catch (RepositoryException rex) {
             LOG.error(rex.getMessage(), rex);
         }
         super.initialize(context, resource);
         try {
-            pckgMgr = PackageUtil.createPackageManager(getRequest());
             pckg = pckgMgr.open(getNode());
             if (pckg != null) {
                 pckgDef = pckg.getDefinition();

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
@@ -33,7 +33,7 @@ public class PackageManagerBean extends ConsoleSlingBean {
         if (type == null) {
             JcrPackageManager manager = null;
             try {
-                manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
+                manager = PackageUtil.getPackageManager(context.getService(Packaging.class), getRequest());
                 type = PackageUtil.getTreeType(manager, getRequest(), getPath());
             } catch (RepositoryException rex) {
                 LOG.error(rex.toString());
@@ -50,8 +50,8 @@ public class PackageManagerBean extends ConsoleSlingBean {
     public List<PackageUtil.PackageItem> getCurrentGroupPackages() {
         List<PackageUtil.PackageItem> items = new ArrayList<>();
         try {
-            JcrPackageManager manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
-            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(manager, request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(context.getService(Packaging.class), getRequest());
+            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(manager, getRequest());
             for (PackageUtil.TreeItem item : treeNode) {
                 if (item instanceof PackageUtil.PackageItem) {
                     if (((PackageUtil.PackageItem) item).getDefinition() != null) {

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
@@ -31,8 +31,13 @@ public class PackageManagerBean extends ConsoleSlingBean {
 
     public String getViewType() {
         if (type == null) {
-            JcrPackageManager manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
-            type = PackageUtil.getTreeType(manager, getRequest(), getPath());
+            JcrPackageManager manager = null;
+            try {
+                manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
+                type = PackageUtil.getTreeType(manager, getRequest(), getPath());
+            } catch (RepositoryException rex) {
+                LOG.error(rex.toString());
+            }
         }
         return type != null ? type.name() : "";
     }

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackageManagerBean.java
@@ -4,6 +4,8 @@ import com.composum.sling.nodes.console.ConsoleSlingBean;
 import com.composum.sling.core.filter.StringFilter;
 import com.composum.sling.core.pckgmgr.util.PackageUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
+import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,8 @@ public class PackageManagerBean extends ConsoleSlingBean {
 
     public String getViewType() {
         if (type == null) {
-            type = PackageUtil.getTreeType(getRequest(), getPath());
+            JcrPackageManager manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
+            type = PackageUtil.getTreeType(manager, getRequest(), getPath());
         }
         return type != null ? type.name() : "";
     }
@@ -42,7 +45,8 @@ public class PackageManagerBean extends ConsoleSlingBean {
     public List<PackageUtil.PackageItem> getCurrentGroupPackages() {
         List<PackageUtil.PackageItem> items = new ArrayList<>();
         try {
-            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(request);
+            JcrPackageManager manager = PackageUtil.getPackageManager(context.getService(Packaging.class), request);
+            PackageUtil.TreeNode treeNode = PackageUtil.getTreeNode(manager, request);
             for (PackageUtil.TreeItem item : treeNode) {
                 if (item instanceof PackageUtil.PackageItem) {
                     if (((PackageUtil.PackageItem) item).getDefinition() != null) {

--- a/sling/core/setup/hook/src/main/java/com/composum/sling/core/setup/hook/SetupHook.java
+++ b/sling/core/setup/hook/src/main/java/com/composum/sling/core/setup/hook/SetupHook.java
@@ -40,7 +40,7 @@ public class SetupHook implements InstallHook {
         }
     }
 
-    protected void moveClientlibsRoot(InstallContext ctx) {
+    protected void moveClientlibsRoot(InstallContext ctx) throws PackageException {
         try {
             Session session = ctx.getSession();
             try {
@@ -75,8 +75,9 @@ public class SetupHook implements InstallHook {
                     session.save();
                 }
             }
-        } catch (RepositoryException ex) {
+        } catch (RepositoryException | RuntimeException ex) {
             LOG.error(ex.getMessage(), ex);
+            throw new PackageException(ex);
         }
     }
 }

--- a/sling/core/setup/util/src/main/java/com/composum/sling/core/setup/util/SetupUtil.java
+++ b/sling/core/setup/util/src/main/java/com/composum/sling/core/setup/util/SetupUtil.java
@@ -25,7 +25,7 @@ public class SetupUtil {
     public static void setupGroupsAndUsers(InstallContext ctx,
                                            Map<String, List<String>> groups,
                                            Map<String, List<String>> systemUsers,
-                                           Map<String, List<String>> users) {
+                                           Map<String, List<String>> users) throws PackageException {
         UserManagementService userManagementService = getService(UserManagementService.class);
         try {
             JackrabbitSession session = (JackrabbitSession) ctx.getSession();
@@ -63,8 +63,9 @@ public class SetupUtil {
                 }
                 session.save();
             }
-        } catch (RepositoryException rex) {
+        } catch (RepositoryException | RuntimeException rex) {
             LOG.error(rex.getMessage(), rex);
+            throw new PackageException(rex);
         }
     }
 


### PR DESCRIPTION
Fixes the annoying warning that PackageUtil.createPackageManager is deprecated by using service Packaging .

Also included: SetupHooks throw a PackageException in case of errors so these get noticed.