### PR TITLE
Rework clientlib permission checks

### DIFF
--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/handle/Clientlib.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/handle/Clientlib.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -40,11 +41,13 @@ public class Clientlib implements ClientlibElement {
     public static final String RESOURCE_TYPE = "composum/nodes/commons/clientlib";
 
     /** A reference that matches this. */
+    @Override
     public ClientlibRef getRef() {
         return new ClientlibRef(getType(), resource.getPath(), true, null);
     }
 
     /** A link that matches this. */
+    @Override
     public ClientlibLink makeLink() {
         return new ClientlibLink(getType(), ClientlibLink.Kind.CLIENTLIB, resource.getPath(), null);
     }
@@ -78,6 +81,7 @@ public class Clientlib implements ClientlibElement {
         return resource.getProperty(PROP_ORDER, 0);
     }
 
+    @Nonnull
     public List<String> getCategories() {
         return Arrays.asList(resource.getProperty(PROP_CATEGORY, new String[0]));
     }

--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/ClientlibService.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/ClientlibService.java
@@ -6,6 +6,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
+import javax.annotation.Nullable;
 import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -68,15 +69,23 @@ public interface ClientlibService {
             outputStream, String encoding) throws IOException, RepositoryException;
 
     /**
-     * Checks that all clientlib items are readable from the given resolver and returns a human readable description
-     * of the results. If that's not the case, this can cause a permanent recalculation of the clientlibs content, or, even worse, break the rendering.
+     * Generates a human readable descriptions of inconsistencies of the client libraries wrt. the given resolver
+     * (or an anonymous resolver, of none is given).
+     * Checks for each client library readable for the given resolver, that all elements of these client libraries
+     * and the files referenced from them are readable, too. Also we check that for all categories either all
+     * client libraries with this reference are readable, or none of them.
+     * All these are errors, since if that's not the case, this can cause a permanent recalculation of the clientlibs content,
+     * or, even worse, break the rendering.
+     * If {onlyErrors} is false, we also include informational messages about all unreadable libraries.
+     *
      *
      * @param type     if not null, only clientlibs / files of that type are checked
-     * @param force    if false, the check is done only if the last run was more than an hour ago. If true, it's done in any case.
      * @param resolver if not null, we use this resolver instead of an anonymous resolver to check readability
+     * @param onlyErrors if true, we skip informational messages
      * @return null if everything is OK, otherwise a description of the problems
      */
-    String verifyClientlibPermissions(Clientlib.Type type, boolean force, ResourceResolver resolver);
+    @Nullable
+    String verifyClientlibPermissions(@Nullable Clientlib.Type type, @Nullable ResourceResolver resolver, boolean onlyErrors);
 
     class ClientlibInfo {
         public Long size;

--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/DefaultClientlibService.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/DefaultClientlibService.java
@@ -6,6 +6,8 @@ import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.concurrent.LazyCreationService;
 import com.composum.sling.core.concurrent.SequencerService;
 import com.composum.sling.core.util.ResourceUtil;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.SetUtils;
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -17,6 +19,7 @@ import org.apache.sling.api.resource.*;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -614,87 +617,146 @@ public class DefaultClientlibService implements ClientlibService {
     protected static final String QUERY_CLIENTLIBS = "/jcr:root/(apps|libs)//*[sling:resourceType='composum/nodes/commons/clientlib']";
 
     /**
-     * Xpath Query suffix for a query that matches all clientlib folders referencing other stuff.
+     * Xpath Query suffix for a query that matches all clientlib folders referencing other stuff: {@value #QUERY_SUFFIX_REFERENCERS}.
      */
     protected static final String QUERY_SUFFIX_REFERENCERS = "[embed or depends]";
 
-    private long lastPermissionCheck = Long.MIN_VALUE;
-
     @Override
-    public String verifyClientlibPermissions(Type requestedtype, boolean force, ResourceResolver resolver) {
-        String querySuffix = requestedtype != null ? "/" + requestedtype.name() + "//*" : "//*";
+    @Nullable
+    public String verifyClientlibPermissions(@Nullable Clientlib.Type requestedType, @Nullable ResourceResolver userResolver, boolean onlyErrors) {
+        String querySuffix = requestedType != null ? "/" + requestedType.name() + "//*" : "//*";
+        String onlyClientlibQuerySuffix = requestedType != null ? "/" + requestedType.name() + "/.." : "";
 
         StringBuilder buf = new StringBuilder();
-        if (force || lastPermissionCheck < System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)) {
-            lastPermissionCheck = System.currentTimeMillis();
-            ResourceResolver checkResolver = resolver;
-            ResourceResolver administrativeResolver = null;
-            try {
-                if (checkResolver == null)
-                    checkResolver = resolverFactory.getResourceResolver(null);
-                administrativeResolver = createAdministrativeResolver();
-                Iterator<Resource> it = administrativeResolver.findResources(QUERY_CLIENTLIBS + querySuffix + " order by path", Query.XPATH);
-                while (it.hasNext()) {
-                    Resource clientlibElement = it.next();
-                    if (checkResolver.getResource(clientlibElement.getPath()) == null) {
-                        buf.append("Cannot be read from given resolver ").append(clientlibElement.getPath()).append("\n");
-                    }
-                }
+        ResourceResolver impersonationResolver = userResolver;
+        ResourceResolver administrativeResolver = null;
+        try {
+            if (impersonationResolver == null)
+                impersonationResolver = resolverFactory.getResourceResolver(null);
+            administrativeResolver = createAdministrativeResolver();
+            List<String> unreachablePaths = new ArrayList<>();
+            Iterator<Resource> it = administrativeResolver.findResources(QUERY_CLIENTLIBS + onlyClientlibQuerySuffix + " order by path", Query.XPATH);
 
-                it = administrativeResolver.findResources(QUERY_CLIENTLIBS + querySuffix + QUERY_SUFFIX_REFERENCERS + " order by path", Query.XPATH);
-                while (it.hasNext()) {
-                    Resource clientlibElement = it.next();
-                    Resource clientlibFolderResource = clientlibElement;
-                    while (!clientlibFolderResource.getParent().isResourceType(RESOURCE_TYPE)) {
-                        clientlibFolderResource = clientlibFolderResource.getParent();
-                    }
-                    Type type = null;
-                    try {
-                        type = Type.valueOf(clientlibFolderResource.getName());
-                    } catch (IllegalArgumentException e) { // very unusual case - folder name other than type?
-                        LOG.info("Cannot recognize type of {}", clientlibElement.getPath());
-                    }
-                    if (type != null) {
-                        ClientlibResourceFolder resourceFolder = new ClientlibResourceFolder(type, clientlibElement);
-                        for (ClientlibRef ref : resourceFolder.getDependencies()) {
-                            verifyRef(ref, administrativeResolver, checkResolver, buf);
-                        }
-                        for (ClientlibRef ref : resourceFolder.getEmbedded()) {
-                            verifyRef(ref, administrativeResolver, checkResolver, buf);
-                        }
-                    }
+            // Check clientlibraries themselves and their categories
+            Set<String> categoriesWithReachableClientlibs = new HashSet<>();
+            Set<String> categoriesWithUnreachableClientlibs = new HashSet<>();
+            while (it.hasNext()) {
+                Resource clientlibElement = it.next();
+                List<String> categories = Arrays.asList(ResourceHandle.use(clientlibElement).getProperty(PROP_CATEGORY, new String[0]));
+                if (impersonationResolver.getResource(clientlibElement.getPath()) == null) {
+                    unreachablePaths.add(clientlibElement.getPath());
+                    categoriesWithUnreachableClientlibs.addAll(categories);
+                } else {
+                    categoriesWithReachableClientlibs.addAll(categories);
                 }
-
-            } catch (LoginException e) {
-                buf.append("Cannot create anonymous or administrative resolver - " + e);
-                LOG.error("Cannot create anonymous or administrative resolver - " + e, e);
-            } catch (Exception e) {
-                LOG.error("Error checking clientlibs", e);
-            } finally {
-                if (null != administrativeResolver) administrativeResolver.close();
-                if (resolver == null) if (null != checkResolver)
-                    checkResolver.close(); // else it's just resolver coming from outside
             }
+            Collection troubledCategories = CollectionUtils.intersection(categoriesWithReachableClientlibs, categoriesWithUnreachableClientlibs);
+            if (!troubledCategories.isEmpty())
+                buf.append("ERROR: Categories with both readable AND unreadable elements: ").append(troubledCategories).append("\n");
+
+            // look for unreadable elements of readable client libraries -> error
+            it = administrativeResolver.findResources(QUERY_CLIENTLIBS + querySuffix + " order by path", Query.XPATH);
+            while (it.hasNext()) {
+                Resource clientlibElement = it.next();
+                if (impersonationResolver.getResource(clientlibElement.getPath()) == null) {
+                    if (!isReachableFrom(unreachablePaths, clientlibElement.getPath())) {
+                        // clientlibs are already there -> this element is surprisingly unreadable.
+                        buf.append("ERROR: unreadable element of readable client library: ")
+                                .append(clientlibElement.getPath()).append("\n");
+                    }
+                    unreachablePaths.add(clientlibElement.getPath());
+                }
+            }
+            unreachablePaths = removeChildren(unreachablePaths);
+            if (!onlyErrors && !unreachablePaths.isEmpty())
+                buf.insert(0, "INFO: Unreadable for this user: " + unreachablePaths + "\n");
+
+            // look for unreadable references of readable elements
+            it = administrativeResolver.findResources(QUERY_CLIENTLIBS + querySuffix + QUERY_SUFFIX_REFERENCERS + " order by path", Query.XPATH);
+            while (it.hasNext()) {
+                Resource clientlibElement = it.next();
+                if (isReachableFrom(unreachablePaths, clientlibElement.getPath()))
+                    continue;
+                Resource clientlibFolderResource = clientlibElement;
+                while (!clientlibFolderResource.getParent().isResourceType(RESOURCE_TYPE)) {
+                    clientlibFolderResource = clientlibFolderResource.getParent();
+                }
+                Type type = null;
+                try {
+                    type = Type.valueOf(clientlibFolderResource.getName());
+                } catch (IllegalArgumentException e) { // very unusual case - folder name other than type?
+                    buf.append("WARN: Cannot recognize type of ").append(clientlibElement.getPath()).append("\n");
+                }
+                if (type != null) {
+                    ClientlibResourceFolder resourceFolder = new ClientlibResourceFolder(type, clientlibElement);
+                    for (ClientlibRef ref : resourceFolder.getDependencies()) {
+                        verifyRef(resourceFolder, ref, administrativeResolver, impersonationResolver, buf);
+                    }
+                    for (ClientlibRef ref : resourceFolder.getEmbedded()) {
+                        verifyRef(resourceFolder, ref, administrativeResolver, impersonationResolver, buf);
+                    }
+                }
+            }
+        } catch (LoginException e) {
+            buf.append("Cannot create anonymous or administrative resolver - " + e);
+            LOG.error("Cannot create anonymous or administrative resolver - " + e, e);
+        } catch (Exception e) {
+            LOG.error("Error checking clientlibs", e);
+        } finally {
+            if (null != administrativeResolver) administrativeResolver.close();
+            if (userResolver == null && null != impersonationResolver)
+                impersonationResolver.close(); // else it's just resolver coming from outside
         }
         return buf.length() == 0 ? null : buf.toString();
     }
 
-    private void verifyRef(ClientlibRef ref, ResourceResolver administrativeResolver, ResourceResolver anonymousResolver, StringBuilder buf) {
+    /** For each path contained here, remove all paths that are children of it, thus removing consequential errors. */
+    protected List<String> removeChildren(List<String> unreachablePaths) {
+        Collections.sort(unreachablePaths); // ancestors appear before children
+        List<String> result = new ArrayList<>();
+        for (String path : unreachablePaths) {
+            if (!isReachableFrom(result, path))
+                result.add(path);
+        }
+        return result;
+    }
+
+    protected boolean isReachableFrom(List<String> paths, String path) {
+        for (String ancestorPath : paths)
+            if (isAncestorOrSelf(ancestorPath, path))
+                return true;
+        return false;
+    }
+
+    /** Returns true if the parent is an {ancestor} of the {resource} (and both are not null, of course. */
+    protected boolean isAncestorOrSelf(@Nullable String parentPath, @Nullable String childPath) {
+        return parentPath != null && childPath != null && (
+                parentPath.equals(childPath) ||
+                        childPath.startsWith(parentPath + "/")
+        );
+    }
+
+    private void verifyRef(ClientlibResourceFolder resourceFolder, ClientlibRef ref, ResourceResolver administrativeResolver, ResourceResolver userResolver, StringBuilder buf) {
         if (ref.isCategory() || ref.isExternalUri()) return;
         Resource resourceAsAdmin = retrieveResource(ref.path, administrativeResolver);
         if (resourceAsAdmin != null) {
-            Resource resourceAsAnonymous = retrieveResource(ref.path, anonymousResolver);
-            if (resourceAsAnonymous == null) {
-                buf.append("Cannot anonymously read ").append(resourceAsAdmin.getPath()).append("\n");
-            } else if (!resourceAsAdmin.getPath().equals(resourceAsAnonymous.getPath())) {
-                buf.append("Permission problem: resource different for admin and anonymous for ")
+            Resource resourceAsUser = retrieveResource(ref.path, userResolver);
+            if (resourceAsUser == null) {
+                buf.append("ERROR: unreadable reference ").append(resourceAsAdmin.getPath())
+                        .append(" of readable client library resource folder ").append(resourceFolder.resource.getPath())
+                        .append("\n");
+            } else if (!resourceAsAdmin.getPath().equals(resourceAsUser.getPath())) {
+                buf.append("ERROR: Permission problem: resource different for admin and anonymous for ")
                         .append(ref.toString())
                         .append(" : ").append(resourceAsAdmin.getPath())
-                        .append(" vs. ").append(resourceAsAnonymous.getPath())
+                        .append(" vs. ").append(resourceAsUser.getPath())
                         .append("\n");
-            } else if (new FileHandle(resourceAsAdmin).isValid() && !new FileHandle(resourceAsAnonymous).isValid()) {
-                buf.append("Content resource not readable: ").append(resourceAsAdmin.getPath()).append("\n");
+            } else if (new FileHandle(resourceAsAdmin).isValid() && !new FileHandle(resourceAsUser).isValid()) {
+                buf.append("ERROR: Content resource not readable: ").append(resourceAsAdmin.getPath()).append("\n");
             }
+        } else {
+            buf.append("ERROR: can't find element ").append(ref.path)
+                    .append(" of resource folder ").append(resourceFolder.resource.getPath()).append("\n");
         }
     }
 

--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/DefaultClientlibService.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/DefaultClientlibService.java
@@ -754,7 +754,7 @@ public class DefaultClientlibService implements ClientlibService {
             } else if (new FileHandle(resourceAsAdmin).isValid() && !new FileHandle(resourceAsUser).isValid()) {
                 buf.append("ERROR: Content resource not readable: ").append(resourceAsAdmin.getPath()).append("\n");
             }
-        } else {
+        } else if (!resourceFolder.getOptional()) {
             buf.append("ERROR: can't find element ").append(ref.path)
                     .append(" of resource folder ").append(resourceFolder.resource.getPath()).append("\n");
         }

--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/ClientlibDebugServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/ClientlibDebugServlet.java
@@ -82,56 +82,6 @@ public class ClientlibDebugServlet extends HttpServlet {
     @Reference
     private ResourceResolverFactory resolverFactory;
 
-    protected void printUsage(HttpServletRequest request, PrintWriter writer, String impersonationparam) {
-        String url = request.getRequestURL().toString().replaceAll("\\.[^/]+$", "") + ".css.html";
-        writer.println("<h3>Usage:</h3>");
-        writer.println("Please give the type of the client library as selector and one or more");
-        writer.println("client libraries or -categories as parameter lib. Some examples:<ul>");
-        printLinkItem(writer, url + "?lib=category:composum.core.console.browser", impersonationparam);
-        printLinkItem(writer, url + "?lib=/libs/composum/nodes/console/clientlibs/base", impersonationparam);
-        printLinkItem(writer, url + "?lib=composum/nodes/console/clientlibs/base", impersonationparam);
-        writer.println("</ul>This prints the files and other included client libraries.");
-        writer.println("It does not check for duplicated elements, as the normal rendering process does.</p>");
-        writer.println("This prints all libraries of the type given as selector, no selector prints all:<ul>");
-        printLinkItem(writer, url, impersonationparam);
-        writer.println("</ul>");
-        writer.flush();
-    }
-
-    protected void printVerification(PrintWriter writer, Type type, ResourceResolver resolver) {
-        String verificationResults = clientlibService.verifyClientlibPermissions(type, true, resolver);
-        if (StringUtils.isNotBlank(verificationResults)) {
-            writer.println("<hr/><h3>Permission warnings:</h3><pre>");
-            writer.println(verificationResults);
-            writer.println("</pre>");
-        }
-    }
-
-    protected void printForm(HttpServletRequest request, PrintWriter writer, Type type) {
-        writer.println("<form action=\"" + request.getRequestURL() + "\" method=\"get\">");
-        writer.println("Type: <select name=\"type\"> <option value=\"all\">All</option>");
-        for (Type selectType : Type.values()) {
-            writer.print("        <option value=\"" + selectType.name() + "\"");
-            if (selectType == type) writer.print(" selected ");
-            writer.print(">" + selectType.name());
-            writer.println("</option>");
-        }
-        writer.println("</select>");
-        writer.print(" Library: <input type=\"text\" name=\"" + REQUEST_PARAM_LIB + "\" value=\"");
-        String lib = request.getParameter(REQUEST_PARAM_LIB);
-        if (lib != null) writer.print(lib);
-        writer.println("\">\n");
-        writer.print(" Impersonate:\n <input type=\"text\" name=\"" + REQUEST_PARAM_IMPERSONATE + "\" value=\"");
-        String impersonate = request.getParameter(REQUEST_PARAM_IMPERSONATE);
-        if (StringUtils.isNotBlank(impersonate)) writer.print(impersonate);
-        writer.println("\">");
-        writer.println("<input type=\"submit\" value=\"Submit\">\n </form>\n");
-    }
-
-    protected void printLinkItem(PrintWriter writer, String url, String impersonationparam) {
-        writer.println("<li><a href=\"" + url + impersonationparam + "\">" + url + "</a></li>");
-    }
-
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         if (request.getRequestURI().endsWith(LOC_CSS)) {
@@ -141,21 +91,31 @@ public class ClientlibDebugServlet extends HttpServlet {
             return;
         }
         response.setContentType("text/html");
-        PrintWriter writer = response.getWriter();
+        final Processor processor = new Processor();
 
-        ResourceResolver resolverToClose = null;
-        ResourceResolver resolver;
+        PrintWriter writer = response.getWriter();
+        processor.writer = response.getWriter();
+        processor.request = request;
+
         String impersonation = request.getParameter(REQUEST_PARAM_IMPERSONATE);
-        String impersonationParam = StringUtils.isNotBlank(impersonation) ? "&" + REQUEST_PARAM_IMPERSONATE + "=" + impersonation.trim() : "";
-        if (request instanceof SlingHttpServletRequest && StringUtils.isBlank(impersonation)) {
-            resolver = ((SlingHttpServletRequest) request).getResourceResolver();
+        processor.impersonationParam = StringUtils.isNotBlank(impersonation) ? "&" + REQUEST_PARAM_IMPERSONATE + "=" + impersonation.trim() : "";
+        try {
+            processor.adminResolver = resolverFactory.getAdministrativeResourceResolver(null);
+        } catch (LoginException e) {
+            throw new ServletException("Cannot get administrative resolver");
+        }
+        if (StringUtils.isBlank(impersonation)) {
+            try {
+                processor.impersonationResolver = resolverFactory.getResourceResolver(null);
+            } catch (LoginException e) { // impossible - so we want to know about it.
+                throw new ServletException("Cannot get anonymous resolver");
+            }
         } else {
             try {
                 Map authenticationInfo = StringUtils.isNotBlank(impersonation) ?
                         new HashMap(Collections.singletonMap(ResourceResolverFactory.USER_IMPERSONATION, impersonation))
                         : null;
-                resolver = resolverFactory.getAdministrativeResourceResolver(authenticationInfo);
-                resolverToClose = resolver;
+                processor.impersonationResolver = resolverFactory.getAdministrativeResourceResolver(authenticationInfo);
             } catch (LoginException e) {
                 writer.println("Could not login as " + impersonation);
                 return;
@@ -163,24 +123,23 @@ public class ClientlibDebugServlet extends HttpServlet {
         }
 
         try {
-            response.setContentType("text/html");
             writer.print("<html><body><h2>Structure of client libraries");
             if (StringUtils.isNotBlank(impersonation))
-                writer.print(" as seen from " + resolver.getUserID());
+                writer.print(" as seen from " + processor.impersonationResolver.getUserID());
             writer.println("</h2>");
 
-            Type requestedType = requestedClientlibType(request);
-            if (requestedType == null && null == request.getParameter(REQUEST_PARAM_LIB)) {
-                printUsage(request, writer, impersonationParam);
+            processor.requestedType = requestedClientlibType(request);
+            if (processor.requestedType == null && null == request.getParameter(REQUEST_PARAM_LIB)) {
+                processor.printUsage();
             }
-            printForm(request, writer, requestedType);
+            processor.printForm();
+            processor.printVerification();
 
-            List<Type> printTypes = requestedType == null ? Arrays.asList(Type.values()) : Collections.singletonList(requestedType);
-            printVerification(writer, requestedType, StringUtils.isNotBlank(impersonation) ? resolver : null);
-
+            List<Type> printTypes = processor.requestedType == null ? Arrays.asList(Type.values()) : Collections.singletonList(processor.requestedType);
             for (Type type : printTypes) {
+                processor.type = type;
                 if (StringUtils.isBlank(request.getParameter(REQUEST_PARAM_LIB)))
-                    printAllLibs(request, writer, type, resolver, impersonationParam);
+                    processor.printAllLibs();
                 else for (String lib : request.getParameterValues(REQUEST_PARAM_LIB)) {
                     ClientlibRef ref;
                     if (lib.startsWith(PREFIX_CATEGORY)) {
@@ -188,13 +147,14 @@ public class ClientlibDebugServlet extends HttpServlet {
                     } else {
                         ref = new ClientlibRef(type, lib, false, null);
                     }
-                    displayClientlibStructure(request, writer, ref, resolver, impersonationParam);
+                    processor.displayClientlibStructure(ref);
                 }
             }
 
             writer.println("<hr/></body></html>");
         } finally {
-            if (null != resolverToClose) resolverToClose.close();
+            processor.adminResolver.close();
+            processor.impersonationResolver.close();
             writer.close();
         }
     }
@@ -212,87 +172,151 @@ public class ClientlibDebugServlet extends HttpServlet {
         return type;
     }
 
-    private void printAllLibs(HttpServletRequest request, PrintWriter writer, Type type, ResourceResolver resolver, String impersonationParam) throws
-            ServletException, IOException {
-        try {
-            QueryManager querymanager = resolver.adaptTo(Session.class).getWorkspace()
-                    .getQueryManager();
-            String statement = "//element(*)[sling:resourceType='composum/nodes/commons/clientlib']/" + type.name() +
-                    "/..  order by path";
-            NodeIterator clientlibsIterator = querymanager.createQuery(statement, Query.XPATH).execute().getNodes();
-            List<Node> clientlibs = IteratorUtils.toList(clientlibsIterator);
-            Collections.sort(clientlibs, new Comparator<Node>() {
-                @Override
-                public int compare(Node o1, Node o2) {
-                    try {
-                        return o1.getPath().compareTo(o2.getPath());
-                    } catch (RepositoryException e) { // can't happen, so we'd want to know.
-                        throw new RuntimeException(e);
+    /** Encapsulates stuff always needed during one request, to avoid passing it on through all methods as parameters. */
+    protected class Processor {
+        Type requestedType;
+        Type type;
+        HttpServletRequest request;
+        PrintWriter writer;
+        ResourceResolver adminResolver;
+        ResourceResolver impersonationResolver;
+        String impersonationParam;
+
+        protected void printUsage() {
+            String url = request.getRequestURL().toString().replaceAll("\\.[^/]+$", "") + ".css.html";
+            writer.println("<h3>Usage:</h3>");
+            writer.println("Please give the type of the client library as selector and one or more");
+            writer.println("client libraries or -categories as parameter lib. Some examples:<ul>");
+            printLinkItem(url + "?lib=category:composum.core.console.browser");
+            printLinkItem(url + "?lib=/libs/composum/nodes/console/clientlibs/base");
+            printLinkItem(url + "?lib=composum/nodes/console/clientlibs/base");
+            writer.println("</ul>This prints the files and other included client libraries.");
+            writer.println("It does not check for duplicated elements, as the normal rendering process does.</p>");
+            writer.println("This prints all libraries of the type given as selector, no selector prints all:<ul>");
+            printLinkItem(url);
+            writer.println("</ul>");
+            writer.flush();
+        }
+
+        protected void printLinkItem(String url) {
+            writer.println("<li><a href=\"" + url + impersonationParam + "\">" + url + "</a></li>");
+        }
+
+        protected void printForm() {
+            writer.println("<form action=\"" + request.getRequestURL() + "\" method=\"get\">");
+            writer.println("Type: <select name=\"type\"> <option value=\"all\">All</option>");
+            for (Type selectType : Type.values()) {
+                writer.print("        <option value=\"" + selectType.name() + "\"");
+                if (selectType == type) writer.print(" selected ");
+                writer.print(">" + selectType.name());
+                writer.println("</option>");
+            }
+            writer.println("</select>");
+            writer.print(" Library: <input type=\"text\" name=\"" + REQUEST_PARAM_LIB + "\" value=\"");
+            String lib = request.getParameter(REQUEST_PARAM_LIB);
+            if (lib != null) writer.print(lib);
+            writer.println("\">\n");
+            writer.print(" Impersonate:\n <input type=\"text\" name=\"" + REQUEST_PARAM_IMPERSONATE + "\" value=\"");
+            String impersonate = request.getParameter(REQUEST_PARAM_IMPERSONATE);
+            if (StringUtils.isNotBlank(impersonate)) writer.print(impersonate);
+            writer.println("\">");
+            writer.println("<input type=\"submit\" value=\"Submit\">\n </form>\n");
+        }
+
+        protected void printVerification() {
+            String verificationResults = clientlibService.verifyClientlibPermissions(type, true, impersonationResolver);
+            if (StringUtils.isNotBlank(verificationResults)) {
+                writer.println("<hr/><h3>Permission warnings:</h3><pre>");
+                writer.println(verificationResults);
+                writer.println("</pre>");
+            }
+        }
+
+        private void printAllLibs() throws ServletException, IOException {
+            try {
+                QueryManager querymanager = adminResolver.adaptTo(Session.class).getWorkspace()
+                        .getQueryManager();
+                String statement = "//element(*)[sling:resourceType='composum/nodes/commons/clientlib']/" + type.name() +
+                        "/..  order by path";
+                NodeIterator clientlibsIterator = querymanager.createQuery(statement, Query.XPATH).execute().getNodes();
+                List<Node> clientlibs = IteratorUtils.toList(clientlibsIterator);
+                Collections.sort(clientlibs, new Comparator<Node>() {
+                    @Override
+                    public int compare(Node o1, Node o2) {
+                        try {
+                            return o1.getPath().compareTo(o2.getPath());
+                        } catch (RepositoryException e) { // can't happen, so we'd want to know.
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+                for (Node clientlib : clientlibs)
+                    displayClientlibStructure(new Clientlib(type, adminResolver.getResource(clientlib.getPath())).getRef());
+
+            } catch (RepositoryException e) {
+                throw new ServletException(e);
+            }
+        }
+
+        /** Displays the structure of one clientlib as seen from the adminResolver - it's rendered like that, anyway. */
+        private void displayClientlibStructure(ClientlibRef ref) throws IOException, ServletException {
+            ClientlibElement clientlib = clientlibService.resolve(ref, adminResolver);
+            String normalizedPath = normalizePath(ref, clientlib);
+            StringBuilder categories = new StringBuilder();
+            String requestUrl = request.getRequestURL().toString();
+            String url = requestUrl.replaceAll("\\.[^/]+$", "") + "." + ref.type.name() + ".html";
+            if (clientlib instanceof Clientlib) {
+                Clientlib thelib = (Clientlib) clientlib;
+                if (thelib.getCategories().isEmpty()) categories.append(" (no categories)");
+                else {
+                    categories.append(" (in categories ");
+                    boolean first = true;
+                    for (String cat : thelib.getCategories()) {
+                        if (!first) categories.append(", ");
+                        first = false;
+                        categories.append("<a href=\"").append(url)
+                                .append("?lib=category:").append(cat).append(impersonationParam)
+                                .append("\">").append(cat).append("</a>");
+                    }
+                    categories.append(")");
+                }
+            }
+            Validate.notNull(clientlib, "Not found: " + ref);
+            writer.println("<hr/>");
+            writer.println("<h3>Structure of <a href=\"" + url + "?lib=" + normalizedPath + impersonationParam + "\">" +
+                    ref + "</a>" + categories + "</h3>");
+            writer.println("<code>&lt;cpn:clientlib type=\"" + ref.type.name() + "\" path=\"" + normalizedPath +
+                    "\"/&gt;</code><br/><hr/><pre>");
+            try {
+                new DebugVisitor(clientlib, clientlibService, adminResolver, writer).execute();
+            } catch (RepositoryException e) {
+                throw new ServletException(e);
+            }
+            writer.println("</pre>");
+        }
+
+        /** Returns the path as it would be in a clientlib reference: relative to search path or a category link */
+        private String normalizePath(ClientlibRef ref, ClientlibElement clientlib) {
+            if (ref.isCategory())
+                return "category:" + ref.category;
+            if (!ref.path.startsWith("/"))
+                return ref.path;
+            for (String pathelement : adminResolver.getSearchPath()) {
+                if (ref.path.startsWith(pathelement)) {
+                    String normalizedPath = ref.path.substring(pathelement.length());
+                    // check whether clientlib is shadowed by other lib in other segments of the search path
+                    ClientlibElement lib2 = clientlibService.resolve(new ClientlibRef(ref.type, normalizedPath, ref
+                            .optional, ref.properties), adminResolver);
+                    if (lib2 instanceof Clientlib) {
+                        Clientlib reresolvedLib = (Clientlib) lib2;
+                        if (reresolvedLib.getRef().path.equals(clientlib.getRef().path))
+                            return normalizedPath;
                     }
                 }
-            });
-            for (Node clientlib : clientlibs)
-                displayClientlibStructure(request, writer,
-                        new Clientlib(type, resolver.getResource(clientlib.getPath())).getRef(), resolver, impersonationParam);
-
-        } catch (RepositoryException e) {
-            throw new ServletException(e);
-        }
-    }
-
-    private void displayClientlibStructure(HttpServletRequest request, PrintWriter writer, ClientlibRef ref, ResourceResolver resolver, String impersonationparam)
-            throws IOException, ServletException {
-        ClientlibElement clientlib = clientlibService.resolve(ref, resolver);
-        String normalizedPath = normalizePath(ref, clientlib, resolver);
-        StringBuilder categories = new StringBuilder();
-        String requestUrl = request.getRequestURL().toString();
-        String url = requestUrl.replaceAll("\\.[^/]+$", "") + "." + ref.type.name() + ".html";
-        if (clientlib instanceof Clientlib) {
-            Clientlib thelib = (Clientlib) clientlib;
-            if (thelib.getCategories().isEmpty()) categories.append(" (no categories)");
-            else {
-                categories.append(" (in categories ");
-                boolean first = true;
-                for (String cat : thelib.getCategories()) {
-                    if (!first) categories.append(", ");
-                    first = false;
-                    categories.append("<a href=\"").append(url)
-                            .append("?lib=category:").append(cat).append(impersonationparam)
-                            .append("\">").append(cat).append("</a>");
-                }
-                categories.append(")");
             }
+            return ref.path;
         }
-        Validate.notNull(clientlib, "Not found: " + ref);
-        writer.println("<hr/>");
-        writer.println("<h3>Structure of <a href=\"" + url + "?lib=" + normalizedPath + impersonationparam + "\">" +
-                ref + "</a>" + categories + "</h3>");
-        writer.println("<code>&lt;cpn:clientlib type=\"" + ref.type.name() + "\" path=\"" + normalizedPath +
-                "\"/&gt;</code><br/><hr/><pre>");
-        try {
-            new DebugVisitor(clientlib, clientlibService, resolver, writer).execute();
-        } catch (RepositoryException e) {
-            throw new ServletException(e);
-        }
-        writer.println("</pre>");
-    }
 
-    private String normalizePath(ClientlibRef ref, ClientlibElement clientlib, ResourceResolver resolver) {
-        if (ref.isCategory()) return "category:" + ref.category;
-        if (!ref.path.startsWith("/")) return ref.path;
-        for (String pathelement : resolver.getSearchPath()) {
-            if (ref.path.startsWith(pathelement)) {
-                String normalizedPath = ref.path.substring(pathelement.length());
-                // check whether clientlib is shadowed by other lib in other segments of the search path
-                ClientlibElement lib2 = clientlibService.resolve(new ClientlibRef(ref.type, normalizedPath, ref
-                        .optional, ref.properties), resolver);
-                if (lib2 instanceof Clientlib) {
-                    Clientlib reresolvedLib = (Clientlib) lib2;
-                    if (reresolvedLib.getRef().path.equals(clientlib.getRef().path)) return normalizedPath;
-                }
-            }
-        }
-        return ref.path;
     }
 
     protected class DebugVisitor extends AbstractClientlibVisitor {

--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/ClientlibDebugServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/ClientlibDebugServlet.java
@@ -109,7 +109,7 @@ public class ClientlibDebugServlet extends HttpServlet {
 
     protected void printForm(HttpServletRequest request, PrintWriter writer, Type type) {
         writer.println("<form action=\"" + request.getRequestURL() + "\" method=\"get\">");
-        writer.println("Type: <select name=\"type\"> <option value=\"\">All</option>");
+        writer.println("Type: <select name=\"type\"> <option value=\"all\">All</option>");
         for (Type selectType : Type.values()) {
             writer.print("        <option value=\"" + selectType.name() + "\"");
             if (selectType == type) writer.print(" selected ");
@@ -164,7 +164,7 @@ public class ClientlibDebugServlet extends HttpServlet {
 
         try {
             response.setContentType("text/html");
-            writer.print("<html><body><h2>Rough structure of client libraries");
+            writer.print("<html><body><h2>Structure of client libraries");
             if (StringUtils.isNotBlank(impersonation))
                 writer.print(" as seen from " + resolver.getUserID());
             writer.println("</h2>");
@@ -205,8 +205,10 @@ public class ClientlibDebugServlet extends HttpServlet {
         Matcher matcher = SELECTOR_REGEX.matcher(uri);
         if (matcher.matches())
             type = Type.valueOf(matcher.group(1));
-        if (StringUtils.isNotBlank(request.getParameter(REQUEST_PARAM_TYPE)))
-            type = Type.valueOf(request.getParameter(REQUEST_PARAM_TYPE));
+        String typeParameter = request.getParameter(REQUEST_PARAM_TYPE);
+        if (StringUtils.isNotBlank(typeParameter)) {
+            type = "all".equalsIgnoreCase(typeParameter) ? null : Type.valueOf(typeParameter);
+        }
         return type;
     }
 
@@ -250,7 +252,10 @@ public class ClientlibDebugServlet extends HttpServlet {
             if (thelib.getCategories().isEmpty()) categories.append(" (no categories)");
             else {
                 categories.append(" (in categories ");
+                boolean first = true;
                 for (String cat : thelib.getCategories()) {
+                    if (!first) categories.append(", ");
+                    first = false;
                     categories.append("<a href=\"").append(url)
                             .append("?lib=category:").append(cat).append(impersonationparam)
                             .append("\">").append(cat).append("</a>");


### PR DESCRIPTION
The client library sling console plugin now prints for the impersonation user:
- informational message what client libraries are unreadable
- errors when a client library is readable but one of it's elements is not
- errors when a client library references unreadable client libraries or files
- errors when something is referenced from a client library but not present in JCR