### PR TITLE
Clientlibs: Plugin to allow clientlib-wise separation of users

### DIFF
--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/ClientlibPermissionPlugin.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/service/ClientlibPermissionPlugin.java
@@ -1,0 +1,31 @@
+package com.composum.sling.clientlibs.service;
+
+import com.composum.sling.core.filter.ResourceFilter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Plugin for the clientlib service that can limit extendability.
+ */
+public interface ClientlibPermissionPlugin {
+
+    /**
+     * Returns limits for the client libraries that are used for the given category. This can be used to avoid
+     * security issues where a malicious user can add client libraries to a category another user uses, and thus
+     * compromise the site of the other user. To avoid this, there has to be a {@link ClientlibPermissionPlugin}
+     * that returns a {@link ResourceFilter} that matches only the areas in the JCR tree the legitimate users
+     * for the site can write to, but not the areas potentially malicious users can write to (e.g. other tenants).
+     * <p>
+     * Caution: If there are several {@link ClientlibPermissionPlugin}s, the {@link ResourceFilter} of all plugins have to be matched.
+     * Thus, if a particular plugin doesn't care about a category, it must return {@link ResourceFilter#ALL}!
+     * We also assume that if the filter matches one path, it should also match all subpaths.
+     *
+     * @param category the name of a category
+     * @return a filter that restricts client libraries that should be included into a category.
+     * not null - return {@link ResourceFilter#ALL} if this {@link ClientlibPermissionPlugin} does not pose a restriction
+     * for a category.
+     */
+    @Nonnull
+    ResourceFilter categoryFilter(@Nonnull String category);
+
+}

--- a/sling/core/test/src/test/java/com/composum/sling/clientlibs/handle/AbstractClientlibTest.java
+++ b/sling/core/test/src/test/java/com/composum/sling/clientlibs/handle/AbstractClientlibTest.java
@@ -9,6 +9,7 @@ import com.composum.sling.core.concurrent.LazyCreationService;
 import com.composum.sling.core.concurrent.LazyCreationServiceImpl;
 import com.composum.sling.core.concurrent.SemaphoreSequencer;
 import com.composum.sling.core.concurrent.SequencerService;
+import com.composum.sling.core.filter.ResourceFilter;
 import com.composum.sling.core.mapping.MappingRules;
 import com.composum.sling.core.util.JsonUtil;
 import com.google.gson.stream.JsonWriter;
@@ -19,6 +20,7 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import javax.jcr.RepositoryException;
@@ -51,6 +53,8 @@ public class AbstractClientlibTest {
 
     protected ExecutorService executorService;
 
+    protected ClientlibPermissionPlugin permissionPlugin;
+
     protected final String CONTEXTPATH = "/context";
 
     /**
@@ -67,6 +71,9 @@ public class AbstractClientlibTest {
 
         final LazyCreationService creationService = context.registerInjectActivateService(
                 new LazyCreationServiceImpl());
+
+        permissionPlugin = Mockito.mock(ClientlibPermissionPlugin.class);
+        Mockito.when(permissionPlugin.categoryFilter(Matchers.anyString())).thenReturn(ResourceFilter.ALL);
 
         configurationService = context.registerService(ClientlibConfiguration.class, new
                 ClientlibConfigurationService() {
@@ -99,10 +106,11 @@ public class AbstractClientlibTest {
                         resolverFactory = context.getService(ResourceResolverFactory.class);
                         sequencer = sequencerService;
                         lazyCreationService = creationService;
+                        permissionPlugins = Arrays.asList(permissionPlugin);
                         activate(context.componentContext());
                     }
                 });
-        // TODO: MockOsgi.activate(clientlibService, context.bundleContext()); should work but doesn't
+        // TODO: MockOsgi.activate(clientlib2Service, context.bundleContext()); should work but doesn't
 
         rendererContext = RendererContext.instance(beanContext, context.request());
 

--- a/sling/core/test/src/test/java/com/composum/sling/clientlibs/handle/ClientlibWithCategoriesTest.java
+++ b/sling/core/test/src/test/java/com/composum/sling/clientlibs/handle/ClientlibWithCategoriesTest.java
@@ -1,10 +1,17 @@
 package com.composum.sling.clientlibs.handle;
 
 import com.composum.sling.clientlibs.processor.RenderingVisitor;
+import com.composum.sling.clientlibs.service.ClientlibPermissionPlugin;
+import com.composum.sling.core.filter.ResourceFilter;
+import com.composum.sling.core.filter.StringFilter;
 import com.composum.sling.core.util.ResourceUtil;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.theories.suppliers.TestedOn;
+import org.mockito.Mockito;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,6 +22,7 @@ import static com.composum.sling.clientlibs.handle.ClientlibResourceFolder.PROP_
 import static com.composum.sling.clientlibs.handle.ClientlibResourceFolder.PROP_EMBED;
 import static com.composum.sling.core.util.ResourceUtil.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests related to clientlibs with categories. This verifies only that categories are used correctly to
@@ -73,6 +81,13 @@ public class ClientlibWithCategoriesTest extends AbstractClientlibTest {
         assertEquals("category:cat1[js:/libs/1]", getClientlibs2("category:cat1", js).toString());
         assertEquals("category:cat2[js:/apps/2.1, js:/apps/2.2]", getClientlibs2("category:cat2", js).toString());
         assertEquals("category:cat3[js:/apps/3]", getClientlibs2("category:cat3", js).toString());
+    }
+
+    @Test
+    public void testRestrictedResolve() throws Exception {
+        Mockito.when(permissionPlugin.categoryFilter("cat2")).thenReturn(
+                new ResourceFilter.PathFilter(new StringFilter.WhiteList("^/apps/2.1")));
+        assertEquals("category:cat2[js:/apps/2.1]", getClientlibs2("category:cat2", js).toString());
     }
 
     @Test


### PR DESCRIPTION
The ClientlibPermissionPlugin allows restriction of the search path for clientlibs per clientlib category. This adresses the potential security problem that one user could add a client library to categories of another user.

The plugin returns a ResourceFilter to allow efficient filtering of the various matches for one category without calling the service multiple times.