### PR TITLE
Feature/status refactoring

### DIFF
--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/processor/AbstractClientlibVisitor.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/processor/AbstractClientlibVisitor.java
@@ -197,7 +197,7 @@ public abstract class AbstractClientlibVisitor implements ClientlibVisitor {
 
     protected void updateHash(String path, Calendar updatetime) {
         LOG.trace("Hashing {} with {}", path, null != updatetime ? updatetime.getTime() : null);
-        embeddedHash = embeddedHash * 92821 + path.hashCode();
+        for (char character : path.toCharArray()) { embeddedHash = embeddedHash * 92821 + character; }
         if (null != updatetime) {
             embeddedHash = embeddedHash * 92821 + updatetime.getTimeInMillis();
         }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/RequestBundle.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/RequestBundle.java
@@ -17,7 +17,7 @@ public class RequestBundle extends ResourceBundle {
     /**
      * returns the requests instance
      */
-    public static synchronized RequestBundle get(SlingHttpServletRequest request) {
+    public static synchronized RequestBundle get(@Nonnull SlingHttpServletRequest request) {
         RequestBundle instance = (RequestBundle) request.getAttribute(ATTRIBUTE_KEY);
         if (instance == null) {
             instance = new RequestBundle(request);
@@ -29,7 +29,7 @@ public class RequestBundle extends ResourceBundle {
     protected final SlingHttpServletRequest request;
     protected final List<BundleItem> bundles;
 
-    protected class BundleWrapper extends ResourceBundle {
+    protected static class BundleWrapper extends ResourceBundle {
 
         protected final ResourceBundle bundle;
 
@@ -37,6 +37,7 @@ public class RequestBundle extends ResourceBundle {
             this.bundle = bundle;
         }
 
+        @Override
         public void setParent(ResourceBundle bundle) {
             super.setParent(bundle);
         }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
@@ -1,5 +1,6 @@
 package com.composum.sling.core.logging;
 
+import com.composum.sling.core.servlet.Status;
 import com.composum.sling.core.util.I18N;
 import com.composum.sling.core.util.LoggerFormat;
 import com.google.gson.TypeAdapterFactory;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A container for a message, e.g. about internal processes, that can be presented to the user. It could be localized,
@@ -37,6 +39,14 @@ public class Message implements Cloneable {
     /** @see #getLevel() */
     protected Level level;
 
+    /** @see #getContext() */
+    @Nullable
+    protected String context;
+
+    /** @see #getLabel() */
+    @Nullable
+    protected String label;
+
     /**
      * If set, an i18n-ed version of {@link #rawText} with all placeholders replaced. This is modified during
      * JSON-serialization.
@@ -55,14 +65,6 @@ public class Message implements Cloneable {
     /** @see #getCategory() */
     @Nullable
     protected String category;
-
-    /** @see #getContext() */
-    @Nullable
-    protected String context;
-
-    /** @see #getLabel() */
-    @Nullable
-    protected String label;
 
     /** @see #getDetails() */
     @Nullable
@@ -415,6 +417,7 @@ public class Message implements Cloneable {
 
     /** Kind of message, also used as loglevel when this is logged. */
     public enum Level {
+
         /**
          * Problems that require the users attention. This usually means that an operation was aborted or yielded
          * errorneous results.
@@ -431,7 +434,18 @@ public class Message implements Cloneable {
          * Detailed informations that are not normally shown to users, but could help to investigate problems if
          * required.
          */
-        debug
+        debug;
+
+        public static final String BOOTSTRAP_ERROR = "danger";
+
+        @Nonnull
+        public static Level levelOf(@Nonnull String name) {
+            if (BOOTSTRAP_ERROR.equalsIgnoreCase(name)) {
+                name = error.name();
+            }
+            return valueOf(name);
+        }
+
     }
 
 }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
@@ -38,16 +38,16 @@ public class Message implements Cloneable {
     protected Level level;
 
     /**
-     * If set, an i18n-ed version of {@link #rawMessage} with all placeholders replaced. This is modified during
+     * If set, an i18n-ed version of {@link #rawText} with all placeholders replaced. This is modified during
      * JSON-serialization.
      */
-    protected String message;
+    protected String text;
 
     /**
-     * The raw version of the message which can contain {@literal {}}-placeholders and is used as
+     * The raw version of the text which can contain {@literal {}}-placeholders and is used as
      * i18n-key.
      */
-    protected String rawMessage;
+    protected String rawText;
 
     /** @see #getArguments() */
     protected Object[] arguments;
@@ -71,9 +71,6 @@ public class Message implements Cloneable {
     /** @see #getTimestamp() */
     protected Long timestamp;
 
-    /** Saves whether the message was already {@link #i18n(SlingHttpServletRequest)}-ized. */
-    protected transient boolean i18lized;
-
     /** @deprecated only for JSON deserialization. */
     @Deprecated
     public Message() {
@@ -83,13 +80,13 @@ public class Message implements Cloneable {
     /**
      * Creates a message.
      *
-     * @param level      the level of the message, default {@link Level#info}
-     * @param rawMessage the message, possibly with placeholders {@literal {}} for arguments
-     * @param arguments  optional arguments placed in placeholders. Caution: must be primitive types if this is to be
-     *                   transmitted with JSON!
+     * @param level     the level of the message, default {@link Level#info}
+     * @param rawText   the untranslated text of message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                  transmitted with JSON!
      */
-    public Message(@Nullable Level level, @Nonnull String rawMessage, Object... arguments) {
-        this.rawMessage = rawMessage;
+    public Message(@Nullable Level level, @Nonnull String rawText, Object... arguments) {
+        this.rawText = rawText;
         this.level = level;
         this.category = category;
         this.arguments = arguments != null && arguments.length > 0 ? arguments : null;
@@ -99,49 +96,49 @@ public class Message implements Cloneable {
     /**
      * Convenience-method - constructs with {@link Level#error}.
      *
-     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param text      the untranslated text of message, possibly with placeholders {@literal {}} for arguments
      * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
      *                  transmitted with JSON!
      */
     @Nonnull
-    public static Message error(@Nonnull String message, Object... arguments) {
-        return new Message(Level.error, message, arguments);
+    public static Message error(@Nonnull String text, Object... arguments) {
+        return new Message(Level.error, text, arguments);
     }
 
     /**
      * Convenience-method - constructs with {@link Level#warn}.
      *
-     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param text      the untranslated text of message, possibly with placeholders {@literal {}} for arguments
      * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
      *                  transmitted with JSON!
      */
     @Nonnull
-    public static Message warn(@Nonnull String message, Object... arguments) {
-        return new Message(Level.warn, message, arguments);
+    public static Message warn(@Nonnull String text, Object... arguments) {
+        return new Message(Level.warn, text, arguments);
     }
 
     /**
      * Convenience-method - constructs with {@link Level#info}.
      *
-     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param text      the untranslated text of message, possibly with placeholders {@literal {}} for arguments
      * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
      *                  transmitted with JSON!
      */
     @Nonnull
-    public static Message info(@Nonnull String message, Object... arguments) {
-        return new Message(Level.info, message, arguments);
+    public static Message info(@Nonnull String text, Object... arguments) {
+        return new Message(Level.info, text, arguments);
     }
 
     /**
      * Convenience-method - constructs with {@link Level#debug}.
      *
-     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param text      the untranslated text of message, possibly with placeholders {@literal {}} for arguments
      * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
      *                  transmitted with JSON!
      */
     @Nonnull
-    public static Message debug(@Nonnull String message, Object... arguments) {
-        return new Message(Level.debug, message, arguments);
+    public static Message debug(@Nonnull String text, Object... arguments) {
+        return new Message(Level.debug, text, arguments);
     }
 
     /**
@@ -179,33 +176,33 @@ public class Message implements Cloneable {
      * If i18n is wanted, this is the key for the i18n - all variable parts should be put into the arguments. Mandatory part of a message.
      */
     @Nonnull
-    public String getRawMessage() {
-        return rawMessage;
+    public String getRawText() {
+        return rawText;
     }
 
     /**
-     * A human readable message text composed from {@link #getRawMessage()}, all argument placeholders {@literal {}}
-     * replaced by the corresponding {@link #getArguments()}. This is lazily created from {@link #getRawMessage()}
-     * and {@link #getArguments()}. In JSON-serializations, the {@link #getRawMessage()} is i18n-ed to the request when
+     * A human readable i18n-ed message text composed from {@link #getRawText()}, all argument placeholders
+     * {@literal {}} replaced by the corresponding {@link #getArguments()}. This is lazily created from {@link #getRawText()}
+     * and {@link #getArguments()}. In JSON-serializations, the {@link #getRawText()} is i18n-ed to the request when
      * {@link MessageTypeAdapterFactory} is correctly used.
      */
     @Nonnull
-    public String getMessage() {
-        if (message != null) { return message; }
-        if (rawMessage == null) { return ""; }
-        message = rawMessage;
+    public String getText() {
+        if (text != null) { return text; }
+        if (rawText == null) { return ""; }
+        text = rawText;
         if (arguments != null && arguments.length > 0) {
-            message = LoggerFormat.format(message, arguments);
+            text = LoggerFormat.format(text, arguments);
         }
-        return message;
+        return text;
     }
 
-    /** Like {@link #getMessage()}, but returns the message localized for the request and parameters replaced. */
+    /** Like {@link #getText()}, but returns the text i18n-ed for the request and parameters replaced. */
     public String getMessage(@Nullable SlingHttpServletRequest request) {
         if (request == null) {
-            return getMessage();
+            return getText();
         }
-        String i18nMessage = rawMessage;
+        String i18nMessage = rawText;
         if (StringUtils.isNotBlank(i18nMessage)) {
             String newMessage = I18N.get(request, i18nMessage);
             if (StringUtils.isNotBlank(newMessage)) {
@@ -221,7 +218,7 @@ public class Message implements Cloneable {
     }
 
     /**
-     * Optional arguments used in placeholders of the {@link #getMessage()}. If transmission over JSON is needed,
+     * Optional arguments used in placeholders of the {@link #getText()}. If transmission over JSON is needed,
      * these must be serializable with GSON.
      */
     @Nonnull
@@ -302,32 +299,13 @@ public class Message implements Cloneable {
         return details != null ? Collections.unmodifiableList(details) : Collections.emptyList();
     }
 
-    /**
-     * Internationalizes the message according to the requests locale. This modifies the message: the
-     * {@link #getMessage()} is looked up as i18n key, and then the arguments are placed into the placeholders and
-     * then cleared. Recommended only after {@link #logInto(Logger)} or {@link #logInto(Logger, Throwable)}.
-     *
-     * @return this message for builder-style operation-chaining.
-     * @deprecated rather register a {@link MessageTypeAdapterFactory#MessageTypeAdapterFactory(SlingHttpServletRequest)}.
-     */
-    @Nonnull
-    @Deprecated
-    public Message i18n(SlingHttpServletRequest request) {
-        if (!i18lized) {
-            message = getMessage(request);
-        } else { // already i18lized - misuse
-            LOG.warn("Second i18n on same message", new Exception("Stacktrace for second i18n, not thrown"));
-        }
-        return this;
-    }
-
     @Override
     public Message clone() throws CloneNotSupportedException {
         return (Message) super.clone();
     }
 
     /**
-     * Clones the {@link Message} and sets its {@link Message#message} to a properly i18n-ed version,
+     * Clones the {@link Message} and sets its {@link Message#text} to a properly i18n-ed version,
      * and also makes Strings out of non-String and non-Numeric arguments to avoid problems with not JSON
      * serializable arguments.
      * <p>
@@ -337,7 +315,7 @@ public class Message implements Cloneable {
      */
     protected Message prepareForJsonSerialization(SlingHttpServletRequest request) throws CloneNotSupportedException {
         Message i18nMessage = clone();
-        i18nMessage.message = getMessage(request);
+        i18nMessage.text = getMessage(request);
         if (arguments != null) {
             i18nMessage.arguments = new Object[arguments.length];
             for (int i = 0; i < arguments.length; ++i) {
@@ -366,7 +344,9 @@ public class Message implements Cloneable {
     }
 
     /**
-     * Logs the message into the specified logger.
+     * Logs the message into the specified logger, including the {cause}'s stacktrace.
+     * Can be done automatically by a {@link MessageContainer} if {@link MessageContainer#MessageContainer(Logger)}
+     * is used.
      *
      * @param log   the log to write the message into
      * @param cause optionally, an exception that is logged as a cause of the message
@@ -404,7 +384,7 @@ public class Message implements Cloneable {
 
     /**
      * Return a full text representation of the message with replaced arguments and appended details. Mainly for
-     * logging / debugging purposes.
+     * logging / debugging purposes. Not i18n-ed.
      */
     public String toFormattedMessage() {
         StringBuilder buf = new StringBuilder();
@@ -418,10 +398,10 @@ public class Message implements Cloneable {
             buf.append(level.name()).append(": ");
         }
         if (arguments != null) {
-            FormattingTuple formatted = MessageFormatter.arrayFormat(message, arguments);
+            FormattingTuple formatted = MessageFormatter.arrayFormat(rawText, arguments);
             buf.append(formatted.getMessage());
         } else {
-            buf.append(message);
+            buf.append(rawText);
         }
         if (details != null) {
             String addIndent = indent + "    ";
@@ -433,6 +413,7 @@ public class Message implements Cloneable {
         }
     }
 
+    /** Kind of message, also used as loglevel when this is logged. */
     public enum Level {
         /**
          * Problems that require the users attention. This usually means that an operation was aborted or yielded

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
@@ -434,23 +434,24 @@ public class Message implements Cloneable {
      */
     @Nonnull
     public Message logInto(@Nullable Logger log, @Nullable Throwable cause) {
+        Throwable loggedCause = cause != null ? cause : getThrowableArgument();
         Level thelevel = getLogLevel();
         thelevel = thelevel != null ? thelevel : getLevel();
         if (log != null) {
             switch (thelevel) {
                 case error:
                     if (log.isErrorEnabled()) {
-                        log.error(toFormattedMessage(), cause);
+                        log.error(toFormattedMessage(), loggedCause);
                     }
                     break;
                 case warn:
                     if (log.isWarnEnabled()) {
-                        log.warn(toFormattedMessage(), cause);
+                        log.warn(toFormattedMessage(), loggedCause);
                     }
                     break;
                 case debug:
                     if (log.isDebugEnabled()) {
-                        log.debug(toFormattedMessage(), cause);
+                        log.debug(toFormattedMessage(), loggedCause);
                     }
                     break;
                 case none:
@@ -458,12 +459,29 @@ public class Message implements Cloneable {
                 case info:
                 default:
                     if (log.isInfoEnabled()) {
-                        log.info(toFormattedMessage(), cause);
+                        log.info(toFormattedMessage(), loggedCause);
                     }
                     break;
             }
         }
         return this;
+    }
+
+    /**
+     * Return the last argument if it is a Throwable. This is the stacktrace logged if there was not given one with
+     * {@link #logInto(Logger, Throwable)} explicitly.
+     * Compatible with slf4j: use last argument if it is an exception http://slf4j.org/faq.html#paramException
+     */
+    @Nullable
+    protected Throwable getThrowableArgument() {
+        Throwable throwable = null;
+        if (arguments != null && arguments.length > 0) {
+            Object possibleThrowable = arguments[arguments.length - 1];
+            if (possibleThrowable instanceof Throwable) {
+                throwable = (Throwable) possibleThrowable;
+            }
+        }
+        return throwable;
     }
 
     /**

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/Message.java
@@ -1,0 +1,456 @@
+package com.composum.sling.core.logging;
+
+import com.composum.sling.core.util.I18N;
+import com.composum.sling.core.util.LoggerFormat;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A container for a message, e.g. about internal processes, that can be presented to the user. It could be localized,
+ * and there might be details which can be suppressed, depending on the user / user settings or choices.
+ * <p>
+ * For proper i18n in JSON serialization you need to register
+ * {@link MessageTypeAdapterFactory#MessageTypeAdapterFactory(SlingHttpServletRequest)} with
+ * {@link com.google.gson.GsonBuilder#registerTypeAdapterFactory(TypeAdapterFactory)}.
+ * The default {@link JsonAdapter} is just a fallback that uses no i18n.
+ * CAUTION: careful when extending this class - the {@link MessageTypeAdapterFactory} might not work for derived classes.
+ */
+@JsonAdapter(MessageTypeAdapterFactory.class)
+public class Message implements Cloneable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Message.class);
+
+    /** @see #getLevel() */
+    protected Level level;
+
+    /**
+     * If set, an i18n-ed version of {@link #rawMessage} with all placeholders replaced. This is modified during
+     * JSON-serialization.
+     */
+    protected String message;
+
+    /**
+     * The raw version of the message which can contain {@literal {}}-placeholders and is used as
+     * i18n-key.
+     */
+    protected String rawMessage;
+
+    /** @see #getArguments() */
+    protected Object[] arguments;
+
+    /** @see #getCategory() */
+    @Nullable
+    protected String category;
+
+    /** @see #getContext() */
+    @Nullable
+    protected String context;
+
+    /** @see #getLabel() */
+    @Nullable
+    protected String label;
+
+    /** @see #getDetails() */
+    @Nullable
+    protected List<Message> details;
+
+    /** @see #getTimestamp() */
+    protected Long timestamp;
+
+    /** Saves whether the message was already {@link #i18n(SlingHttpServletRequest)}-ized. */
+    protected transient boolean i18lized;
+
+    /** @deprecated only for JSON deserialization. */
+    @Deprecated
+    public Message() {
+        // empty
+    }
+
+    /**
+     * Creates a message.
+     *
+     * @param level      the level of the message, default {@link Level#info}
+     * @param rawMessage the message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments  optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                   transmitted with JSON!
+     */
+    public Message(@Nullable Level level, @Nonnull String rawMessage, Object... arguments) {
+        this.rawMessage = rawMessage;
+        this.level = level;
+        this.category = category;
+        this.arguments = arguments != null && arguments.length > 0 ? arguments : null;
+        timestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * Convenience-method - constructs with {@link Level#error}.
+     *
+     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                  transmitted with JSON!
+     */
+    @Nonnull
+    public static Message error(@Nonnull String message, Object... arguments) {
+        return new Message(Level.error, message, arguments);
+    }
+
+    /**
+     * Convenience-method - constructs with {@link Level#warn}.
+     *
+     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                  transmitted with JSON!
+     */
+    @Nonnull
+    public static Message warn(@Nonnull String message, Object... arguments) {
+        return new Message(Level.warn, message, arguments);
+    }
+
+    /**
+     * Convenience-method - constructs with {@link Level#info}.
+     *
+     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                  transmitted with JSON!
+     */
+    @Nonnull
+    public static Message info(@Nonnull String message, Object... arguments) {
+        return new Message(Level.info, message, arguments);
+    }
+
+    /**
+     * Convenience-method - constructs with {@link Level#debug}.
+     *
+     * @param message   the message, possibly with placeholders {@literal {}} for arguments
+     * @param arguments optional arguments placed in placeholders. Caution: must be primitive types if this is to be
+     *                  transmitted with JSON!
+     */
+    @Nonnull
+    public static Message debug(@Nonnull String message, Object... arguments) {
+        return new Message(Level.debug, message, arguments);
+    }
+
+    /**
+     * Adds a detailmessage.
+     *
+     * @return this for builder style operation chaining.
+     */
+    @Nonnull
+    public Message addDetail(@Nonnull Message detailMessage) {
+        if (details == null) { details = new ArrayList<>(); }
+        details.add(detailMessage);
+        return this;
+    }
+
+    /** Time the message was created, as in {@link System#currentTimeMillis()}. */
+    @Nullable
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    /** Time the message was created. */
+    @Nullable
+    public Date getTimestampAsDate() {
+        return timestamp != null ? new Date(timestamp) : null;
+    }
+
+    /** The kind of message - informational, warning, error. Default is {@link Level#info}. */
+    @Nonnull
+    public Level getLevel() {
+        return level != null ? level : Level.info;
+    }
+
+    /**
+     * The raw, un-i18n-ed, human readable message text, possibly with argument placeholders {@literal {}}.
+     * If i18n is wanted, this is the key for the i18n - all variable parts should be put into the arguments. Mandatory part of a message.
+     */
+    @Nonnull
+    public String getRawMessage() {
+        return rawMessage;
+    }
+
+    /**
+     * A human readable message text composed from {@link #getRawMessage()}, all argument placeholders {@literal {}}
+     * replaced by the corresponding {@link #getArguments()}. This is lazily created from {@link #getRawMessage()}
+     * and {@link #getArguments()}. In JSON-serializations, the {@link #getRawMessage()} is i18n-ed to the request when
+     * {@link MessageTypeAdapterFactory} is correctly used.
+     */
+    @Nonnull
+    public String getMessage() {
+        if (message != null) { return message; }
+        if (rawMessage == null) { return ""; }
+        message = rawMessage;
+        if (arguments != null && arguments.length > 0) {
+            message = LoggerFormat.format(message, arguments);
+        }
+        return message;
+    }
+
+    /** Like {@link #getMessage()}, but returns the message localized for the request and parameters replaced. */
+    public String getMessage(@Nullable SlingHttpServletRequest request) {
+        if (request == null) {
+            return getMessage();
+        }
+        String i18nMessage = rawMessage;
+        if (StringUtils.isNotBlank(i18nMessage)) {
+            String newMessage = I18N.get(request, i18nMessage);
+            if (StringUtils.isNotBlank(newMessage)) {
+                i18nMessage = newMessage;
+            }
+            if (arguments != null && arguments.length > 0) {
+                i18nMessage = LoggerFormat.format(i18nMessage, arguments);
+            }
+        } else {
+            i18nMessage = "";
+        }
+        return i18nMessage;
+    }
+
+    /**
+     * Optional arguments used in placeholders of the {@link #getMessage()}. If transmission over JSON is needed,
+     * these must be serializable with GSON.
+     */
+    @Nonnull
+    public List<Object> getArguments() {
+        return arguments != null ? Arrays.asList(arguments) : Collections.emptyList();
+    }
+
+    /**
+     * Can optionally be used to categorize messages for filtering / sorting. This is not meant to be shown directly
+     * to the user.
+     */
+    @Nullable
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * Sets the optional category: can optionally be used to categorize messages for filtering / sorting. This is not
+     * meant to be shown directly to the user.
+     *
+     * @return this for builder style operation chaining.
+     */
+    @Nonnull
+    public Message setCategory(@Nullable String category) {
+        this.category = category;
+        return this;
+    }
+
+    /**
+     * Optional: label of the field which the message is about, primarily in validation messages. (Not the
+     * human-readable but the programmatical id is meant.)
+     */
+    @Nullable
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Sets the optional context: a label of the field which the message is about, primarily in validation messages.
+     * (Not the human-readable but the programmatical id is meant.)
+     *
+     * @return this for builder style operation chaining.
+     */
+    @Nonnull
+    public Message setLabel(@Nullable String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Optional: a context of the message, such as the dialog tab in a validation message. (Not the
+     * human-readable but the programmatical id is meant.)
+     */
+    @Nullable
+    public String getContext() {
+        return context;
+    }
+
+    /**
+     * Sets a context: a context of the message, such as the dialog tab in a validation message. (Not the
+     * human-readable but the programmatical id is meant.)
+     *
+     * @return this for builder style operation chaining.
+     */
+    @Nonnull
+    public Message setContext(@Nullable String context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Optional unmodifiable collection of detail messages describing the problem further. To add details use {@link #addDetail(Message)}.
+     *
+     * @see #addDetail(Message)
+     */
+    @Nonnull
+    public List<Message> getDetails() {
+        return details != null ? Collections.unmodifiableList(details) : Collections.emptyList();
+    }
+
+    /**
+     * Internationalizes the message according to the requests locale. This modifies the message: the
+     * {@link #getMessage()} is looked up as i18n key, and then the arguments are placed into the placeholders and
+     * then cleared. Recommended only after {@link #logInto(Logger)} or {@link #logInto(Logger, Throwable)}.
+     *
+     * @return this message for builder-style operation-chaining.
+     * @deprecated rather register a {@link MessageTypeAdapterFactory#MessageTypeAdapterFactory(SlingHttpServletRequest)}.
+     */
+    @Nonnull
+    @Deprecated
+    public Message i18n(SlingHttpServletRequest request) {
+        if (!i18lized) {
+            message = getMessage(request);
+        } else { // already i18lized - misuse
+            LOG.warn("Second i18n on same message", new Exception("Stacktrace for second i18n, not thrown"));
+        }
+        return this;
+    }
+
+    @Override
+    public Message clone() throws CloneNotSupportedException {
+        return (Message) super.clone();
+    }
+
+    /**
+     * Clones the {@link Message} and sets its {@link Message#message} to a properly i18n-ed version,
+     * and also makes Strings out of non-String and non-Numeric arguments to avoid problems with not JSON
+     * serializable arguments.
+     * <p>
+     * Tradeoff: keeping numbers is more efficient but GSON turns numbers into doubles on deserialization
+     * which sometimes creates differences when formatting is repeated on a serialized and deserialized
+     * {@link Message}.
+     */
+    protected Message prepareForJsonSerialization(SlingHttpServletRequest request) throws CloneNotSupportedException {
+        Message i18nMessage = clone();
+        i18nMessage.message = getMessage(request);
+        if (arguments != null) {
+            i18nMessage.arguments = new Object[arguments.length];
+            for (int i = 0; i < arguments.length; ++i) {
+                Object arg = arguments[i];
+                if ((arg instanceof String) || (arg instanceof Number)) {
+                    i18nMessage.arguments[i] = arg;
+                } else {
+                    i18nMessage.arguments[i] = LoggerFormat.format("{}", arg);
+                }
+            }
+        }
+        return i18nMessage;
+    }
+
+    /**
+     * Logs the message into the specified logger. Can be done automatically by a {@link MessageContainer} if
+     * {@link MessageContainer#MessageContainer(Logger)} is used.
+     *
+     * @param log the log to write the message into
+     * @return this message for builder-style operation-chaining.
+     * @see MessageContainer#MessageContainer(Logger)
+     */
+    @Nonnull
+    public Message logInto(@Nullable Logger log) {
+        return logInto(log, null);
+    }
+
+    /**
+     * Logs the message into the specified logger.
+     *
+     * @param log   the log to write the message into
+     * @param cause optionally, an exception that is logged as a cause of the message
+     * @return this message for builder-style operation-chaining.
+     */
+    @Nonnull
+    public Message logInto(@Nonnull Logger log, @Nullable Throwable cause) {
+        if (log != null) {
+            switch (getLevel()) {
+                case error:
+                    if (log.isErrorEnabled()) {
+                        log.error(toFormattedMessage(), cause);
+                    }
+                    break;
+                case warn:
+                    if (log.isWarnEnabled()) {
+                        log.warn(toFormattedMessage(), cause);
+                    }
+                    break;
+                case debug:
+                    if (log.isDebugEnabled()) {
+                        log.debug(toFormattedMessage(), cause);
+                    }
+                    break;
+                case info:
+                default:
+                    if (log.isInfoEnabled()) {
+                        log.info(toFormattedMessage(), cause);
+                    }
+                    break;
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Return a full text representation of the message with replaced arguments and appended details. Mainly for
+     * logging / debugging purposes.
+     */
+    public String toFormattedMessage() {
+        StringBuilder buf = new StringBuilder();
+        appendFormattedTo(buf, "", level);
+        return buf.toString();
+    }
+
+    protected void appendFormattedTo(StringBuilder buf, String indent, Level baseLevel) {
+        buf.append(indent);
+        if (level != null && baseLevel != null && level != baseLevel) {
+            buf.append(level.name()).append(": ");
+        }
+        if (arguments != null) {
+            FormattingTuple formatted = MessageFormatter.arrayFormat(message, arguments);
+            buf.append(formatted.getMessage());
+        } else {
+            buf.append(message);
+        }
+        if (details != null) {
+            String addIndent = indent + "    ";
+            buf.append("\n").append(addIndent).append("Details:");
+            for (Message detail : details) {
+                buf.append("\n");
+                detail.appendFormattedTo(buf, addIndent, baseLevel);
+            }
+        }
+    }
+
+    public enum Level {
+        /**
+         * Problems that require the users attention. This usually means that an operation was aborted or yielded
+         * errorneous results.
+         */
+        error,
+        /**
+         * A warning that might or might not indicate that the result of an operation could have had errorneous
+         * results.
+         */
+        warn,
+        /** Informational messages for further details. */
+        info,
+        /**
+         * Detailed informations that are not normally shown to users, but could help to investigate problems if
+         * required.
+         */
+        debug
+    }
+
+}

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
@@ -92,6 +92,17 @@ public class MessageContainer implements Iterable<Message> {
     }
 
     /**
+     * Logs the messages into the given container. This is automatically done on {@link #add(Message)} if a logger
+     * is set, but this might be necessary after deserializing the container.
+     */
+    public void logInto(@Nullable Logger logger) {
+        if (logger == null) { return; }
+        for (Message message : getMessages()) {
+            message.logInto(logger);
+        }
+    }
+
+    /**
      * Removes all messages.
      *
      * @return this MessageContainer, for builder-style operation chaining.

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
@@ -10,12 +10,15 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
 /** A collection of {@link Message}s for humans - also meant for transmitting them via JSON. */
 @ThreadSafe
 @JsonAdapter(MessageTypeAdapterFactory.class)
-public class MessageContainer {
+public class MessageContainer implements Iterable<Message> {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageContainer.class);
 
@@ -47,7 +50,7 @@ public class MessageContainer {
         this.log = log;
     }
 
-    /** A (unmodifiable) list of messages. */
+    /** A (unmodifiable) snapshot of the list of messages. */
     @Nonnull
     public List<Message> getMessages() {
         synchronized (lockObject) {
@@ -109,26 +112,22 @@ public class MessageContainer {
         }
     }
 
-    /**
-     * Internationalizes the message according to the requests locale. This modifies the messages - see
-     * {@link Message#i18n(SlingHttpServletRequest)}.
-     *
-     * @return this container for builder-style operation-chaining.
-     * @see Message#i18n(SlingHttpServletRequest)
-     * @deprecated rather register a {@link MessageTypeAdapterFactory#MessageTypeAdapterFactory(SlingHttpServletRequest)}.
-     */
-    // FIXME(hps,15.01.20) remove usages
-    @Deprecated
-    @Nonnull
-    public MessageContainer i18n(@Nonnull SlingHttpServletRequest request) {
-        synchronized (lockObject) {
-            if (messages != null) {
-                for (Message message : messages) {
-                    message.i18n(request);
-                }
-            }
-        }
-        return this;
+    /** Iterates over a readonly view. */
+    @Override
+    public Iterator<Message> iterator() {
+        return getMessages().iterator();
+    }
+
+    /** Iterates over a readonly view. */
+    @Override
+    public void forEach(Consumer<? super Message> action) {
+        getMessages().forEach(action);
+    }
+
+    /** Iterates over a readonly view. */
+    @Override
+    public Spliterator<Message> spliterator() {
+        return getMessages().spliterator();
     }
 
 }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
@@ -1,0 +1,134 @@
+package com.composum.sling.core.logging;
+
+import com.google.gson.annotations.JsonAdapter;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** A collection of {@link Message}s for humans - also meant for transmitting them via JSON. */
+@ThreadSafe
+@JsonAdapter(MessageTypeAdapterFactory.class)
+public class MessageContainer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageContainer.class);
+
+    /** A logger where {@link #add(Message)} automatically logs to. */
+    @Nullable
+    protected transient final Logger log;
+
+    /** Synchronizing on this when accessing messages. */
+    protected transient final Object lockObject = new Object();
+
+    /** @see #getMessages() */
+    @Nullable
+    protected List<Message> messages;
+
+    /**
+     * Default constructor which means we do not log added messages - usually it's better to use
+     * {@link #MessageContainer(Logger)} and log things immediately.
+     */
+    public MessageContainer() {
+        log = null;
+    }
+
+    /**
+     * Constructor that allows to set a logger to which {@link #add(Message)} automatically writes the messages.
+     *
+     * @param log an optional log to which added messages are logged.
+     */
+    public MessageContainer(@Nullable Logger log) {
+        this.log = log;
+    }
+
+    /** A (unmodifiable) list of messages. */
+    @Nonnull
+    public List<Message> getMessages() {
+        synchronized (lockObject) {
+            return messages != null ? Collections.unmodifiableList(new ArrayList<>(messages)) : Collections.emptyList();
+        }
+    }
+
+    /**
+     * Adds a message to the container, and logs it into the logger if one was specified for this container.
+     * The intended usecase is with a logger, so we log a warning if it's called with a throwable but
+     * we have no logger, so that Stacktraces don't disappear accidentially.
+     *
+     * @return this MessageContainer, for builder-style operation chaining.
+     */
+    @Nonnull
+    public MessageContainer add(@Nullable Message message, @Nullable Throwable throwable) {
+        if (message != null) {
+            synchronized (lockObject) {
+                if (messages == null) { messages = new ArrayList<>(); }
+                messages.add(message);
+            }
+            if (log != null) {
+                message.logInto(log, throwable);
+            } else if (throwable != null) { // very likely a misuse
+                LOG.warn("Received throwable but have no logger: {}", message.toFormattedMessage(), throwable);
+            }
+
+        }
+        return this;
+    }
+
+    /**
+     * Adds a message to the container, and logs it into the logger if one was specified for this container.
+     *
+     * @return this MessageContainer, for builder-style operation chaining.
+     */
+    @Nonnull
+    public MessageContainer add(@Nullable Message message) {
+        return add(message, null);
+    }
+
+    /**
+     * Removes all messages.
+     *
+     * @return this MessageContainer, for builder-style operation chaining.
+     */
+    @Nonnull
+    public MessageContainer clear() {
+        synchronized (lockObject) {
+            messages = null;
+        }
+        return this;
+    }
+
+    /** Whether there are any messages. */
+    public boolean isEmpty() {
+        synchronized (lockObject) {
+            return messages == null || messages.isEmpty();
+        }
+    }
+
+    /**
+     * Internationalizes the message according to the requests locale. This modifies the messages - see
+     * {@link Message#i18n(SlingHttpServletRequest)}.
+     *
+     * @return this container for builder-style operation-chaining.
+     * @see Message#i18n(SlingHttpServletRequest)
+     * @deprecated rather register a {@link MessageTypeAdapterFactory#MessageTypeAdapterFactory(SlingHttpServletRequest)}.
+     */
+    // FIXME(hps,15.01.20) remove usages
+    @Deprecated
+    @Nonnull
+    public MessageContainer i18n(@Nonnull SlingHttpServletRequest request) {
+        synchronized (lockObject) {
+            if (messages != null) {
+                for (Message message : messages) {
+                    message.i18n(request);
+                }
+            }
+        }
+        return this;
+    }
+
+}

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageContainer.java
@@ -1,7 +1,6 @@
 package com.composum.sling.core.logging;
 
 import com.google.gson.annotations.JsonAdapter;
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +23,7 @@ public class MessageContainer implements Iterable<Message> {
 
     /** A logger where {@link #add(Message)} automatically logs to. */
     @Nullable
-    protected transient final Logger log;
+    protected volatile transient Logger log;
 
     /** Synchronizing on this when accessing messages. */
     protected transient final Object lockObject = new Object();
@@ -130,4 +129,11 @@ public class MessageContainer implements Iterable<Message> {
         return getMessages().spliterator();
     }
 
+    /**
+     * Modifies the logger newly {@link #add(Message)}-ed / {@link #add(Message, Throwable)}-ed messages are logged
+     * to.
+     */
+    public void setLogger(Logger logger) {
+        this.log = logger;
+    }
 }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
@@ -82,10 +82,9 @@ public class MessageTypeAdapterFactory implements TypeAdapterFactory {
         public void write(JsonWriter out, MessageContainer container) throws IOException {
             if (container != null) {
                 out.beginArray();
-                if (container.messages != null) {
-                    for (Message msg : container.messages) {
-                        gson.toJson(msg, msg.getClass(), out);
-                    }
+                for (Message msg : container.getMessages()) {
+                    // use getMessages() to avoid concurrency problems - returns a snapshot
+                    gson.toJson(msg, msg.getClass(), out);
                 }
                 out.endArray();
             } else {

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
@@ -1,0 +1,138 @@
+package com.composum.sling.core.logging;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Creates a {@link TypeAdapter} for the JSON (de-)serialization of {@link MessageContainer}s and {@link Message}s.
+ * In this implementation it only handles exactly {@link MessageContainer} and {@link Message}, no derived classes.
+ * <p>
+ * The {@link TypeAdapter} serializes the {@link MessageContainer} to a JSON array of GSON serialized messages
+ * and takes care of i18n.
+ * <p>
+ * Considerations for i18n: If a {@link Message} is delivered in a response, it should normally contain the i18n-ed message
+ * with all placeholders replaced by the arguments as attribute "message". However, we also want to transfer the raw
+ * data (un-i18n-ed message and the arguments) to be able to generate several i18ns (e.g. when logging audit-data in
+ * a business-language). So we also transmit the raw data: "rawMessage" and "arguments" (as {@link Object#toString()}).
+ */
+public class MessageTypeAdapterFactory implements TypeAdapterFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageTypeAdapterFactory.class);
+
+    @Nullable
+    protected final SlingHttpServletRequest request;
+
+    /** Default constructor, e.g. if used with {@link JsonAdapter}. */
+    public MessageTypeAdapterFactory() {
+        this(null);
+    }
+
+    /** If you want i18n. For use with {@link com.google.gson.GsonBuilder#registerTypeAdapterFactory(TypeAdapterFactory)}. */
+    public MessageTypeAdapterFactory(@Nullable SlingHttpServletRequest request) {
+        this.request = request;
+    }
+
+    @SuppressWarnings({"unchecked", "NullabilityAnnotations"})
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        LOG.info("create called for " + type);
+        if (MessageContainer.class.equals(type.getRawType())) {
+            return (TypeAdapter<T>) new MessageContainerTypeAdapter(gson);
+        }
+        if (Message.class.isAssignableFrom(type.getRawType())) {
+            TypeAdapter<Message> defaultGsonAdapter = (TypeAdapter<Message>) gson.getDelegateAdapter(this, type);
+            return (TypeAdapter<T>) new MessageTypeAdapter(gson, Objects.requireNonNull(defaultGsonAdapter));
+        }
+        return null;
+    }
+
+    protected static class MessageContainerTypeAdapter extends TypeAdapter<MessageContainer> {
+        @Nonnull
+        protected final Gson gson;
+
+        public MessageContainerTypeAdapter(@Nonnull Gson gson) {
+            this.gson = gson;
+        }
+
+        @SuppressWarnings("resource")
+        @Override
+        public void write(JsonWriter out, MessageContainer container) throws IOException {
+            if (container != null) {
+                out.beginArray();
+                if (container.messages != null) {
+                    for (Message msg : container.messages) {
+                        gson.toJson(msg, msg.getClass(), out);
+                    }
+                }
+                out.endArray();
+            } else {
+                out.nullValue();
+            }
+        }
+
+        @Override
+        public MessageContainer read(JsonReader in) throws IOException {
+            MessageContainer container = new MessageContainer();
+            in.beginArray();
+            while (in.hasNext()) { container.add(gson.fromJson(in, Message.class));}
+            in.endArray();
+            return container;
+        }
+    }
+
+    protected class MessageTypeAdapter extends TypeAdapter<Message> {
+        @Nonnull
+        protected final Gson gson;
+
+        @Nonnull
+        protected final TypeAdapter<Message> defaultGsonAdapter;
+
+        public MessageTypeAdapter(@Nonnull Gson gson, @Nonnull TypeAdapter<Message> defaultGsonAdapter) {
+            this.gson = gson;
+            this.defaultGsonAdapter = defaultGsonAdapter;
+        }
+
+        @SuppressWarnings("resource")
+        @Override
+        public void write(JsonWriter out, Message value) throws IOException {
+            if (value != null) {
+                // to avoid touching the original message to set the message attribute, we clone it first.
+                Message i18nMessage = prepareI18nMessage(value);
+                defaultGsonAdapter.write(out, i18nMessage);
+            } else {
+                out.nullValue();
+            }
+        }
+
+        /** @see Message#prepareForJsonSerialization(SlingHttpServletRequest) */
+        @Nonnull
+        protected Message prepareI18nMessage(@Nonnull Message value) {
+            Message i18nMessage = value;
+            try {
+                i18nMessage = value.prepareForJsonSerialization(request);
+            } catch (CloneNotSupportedException impossible) {
+                LOG.error("Could not clone " + value.getClass(), impossible);
+                i18nMessage.getMessage(); // make sure that i18nmessage.message at least contains something.
+            }
+            return i18nMessage;
+        }
+
+        @Override
+        public Message read(JsonReader in) throws IOException {
+            return defaultGsonAdapter.read(in);
+        }
+    }
+}

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
@@ -59,7 +59,6 @@ public class MessageTypeAdapterFactory implements TypeAdapterFactory {
     @SuppressWarnings({"unchecked", "NullabilityAnnotations", "ReturnOfNull"})
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-        LOG.info("create called for {}", type);
         if (MessageContainer.class.equals(type.getRawType())) {
             return (TypeAdapter<T>) new MessageContainerTypeAdapter(gson);
         }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/logging/MessageTypeAdapterFactory.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Considerations for i18n: If a {@link Message} is delivered in a response, it should normally contain the i18n-ed message
  * with all placeholders replaced by the arguments as attribute "message". However, we also want to transfer the raw
  * data (un-i18n-ed message and the arguments) to be able to generate several i18ns (e.g. when logging audit-data in
- * a business-language). So we also transmit the raw data: "rawMessage" and "arguments" (as {@link Object#toString()}).
+ * a business-language). So we also transmit the raw data: "rawText" and "arguments" (as {@link Object#toString()}).
  */
 public class MessageTypeAdapterFactory implements TypeAdapterFactory {
 
@@ -125,7 +125,7 @@ public class MessageTypeAdapterFactory implements TypeAdapterFactory {
                 i18nMessage = value.prepareForJsonSerialization(request);
             } catch (CloneNotSupportedException impossible) {
                 LOG.error("Could not clone " + value.getClass(), impossible);
-                i18nMessage.getMessage(); // make sure that i18nmessage.message at least contains something.
+                i18nMessage.getText(); // make sure that i18nmessage.message at least contains something.
             }
             return i18nMessage;
         }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/service/TranslationService.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/service/TranslationService.java
@@ -8,7 +8,7 @@ import java.io.Reader;
 import java.io.Writer;
 
 /**
- * Permission and Member check service
+ * Translates all strings in a JSON.
  */
 public interface TranslationService {
 

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -80,6 +80,10 @@ public class Status {
         this(new GsonBuilder(), request, response, messageLogger);
     }
 
+    /**
+     * Constructor without logging messages - consider {@link #Status(SlingHttpServletRequest, SlingHttpServletResponse, Logger)}
+     * to automatically log added messages.
+     */
     public Status(@Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
         this(new GsonBuilder(), request, response, null);
     }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -71,15 +72,31 @@ public class Status {
 
     public class Message {
 
+        @Nonnull
         public final Level level;
+
+        /** In validation messages: context of the validation, for instance the dialog tab. */
+        @Nullable
         public final String context;
+
+        /** In validation messages: label of the field which the message is about. */
+        @Nullable
         public final String label;
+
+        /** The text of the message, can contain {@literal {}} placeholders. */
+        @Nonnull
         public final String text;
 
+        /** @param text The text of the message, can contain {@literal {}} placeholders. */
         public Message(@Nonnull final Level level, @Nonnull final String text) {
             this(level, null, null, text);
         }
 
+        /**
+         * @param context In validation messages: context of the validation, for instance the dialog tab.
+         * @param label   In validation messages: label of the field which the message is about.
+         * @param text    The text of the message, can contain {@literal {}} placeholders.
+         */
         public Message(@Nonnull final Level level,
                        @Nullable final String context, @Nullable final String label,
                        @Nonnull final String text) {
@@ -223,31 +240,37 @@ public class Status {
         return !isSuccess();
     }
 
+    /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
     public void info(@Nonnull final String text, Object... args) {
         shortMessage(Level.info, text, args);
     }
 
-    public void info(@Nonnull final String context, @Nonnull final String label,
-                     @Nonnull final String text, Object... args) {
-        addMessage(Level.info, context, label, text, args);
+    /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+    public void validationInfo(@Nonnull final String context, @Nonnull final String label,
+                               @Nonnull final String text, Object... args) {
+        addValidationMessage(Level.info, context, label, text, args);
     }
 
+    /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
     public void warn(@Nonnull final String text, Object... args) {
         shortMessage(Level.warn, text, args);
     }
 
-    public void warn(@Nonnull final String context, @Nonnull final String label,
-                     @Nonnull final String text, Object... args) {
-        addMessage(Level.warn, context, label, text, args);
+    /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+    public void validationWarn(@Nonnull final String context, @Nonnull final String label,
+                               @Nonnull final String text, Object... args) {
+        addValidationMessage(Level.warn, context, label, text, args);
     }
 
+    /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
     public void error(@Nonnull final String text, Object... args) {
         shortMessage(Level.error, text, args);
     }
 
-    public void error(@Nonnull final String context, @Nonnull final String label,
-                      @Nonnull final String text, Object... args) {
-        addMessage(Level.error, context, label, text, args);
+    /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+    public void validationError(@Nonnull final String context, @Nonnull final String label,
+                                @Nonnull final String text, Object... args) {
+        addValidationMessage(Level.error, context, label, text, args);
     }
 
     /**
@@ -324,21 +347,24 @@ public class Status {
 
     /**
      * @param level the message level
-     * @param text  non prepared text message
-     * @param args  argument objects for the log like message preparation
+     * @param text  non prepared text message, may contain {@literal {}} placeholders
+     * @param args  argument objects for the log like message preparation of text
      */
     public void shortMessage(@Nonnull final Level level, @Nonnull final String text, Object... args) {
-        addMessage(level, null, null, prepare(text, args));
+        addValidationMessage(level, null, null, prepare(text, args));
     }
 
     /**
+     * For use with validation messages: add context and label, too.
+     *
      * @param level   the message level
      * @param context non prepared context key
      * @param label   non prepared aspect label (validation label)
-     * @param text    pre prepared text message
+     * @param text    non prepared text message, can contain placeholders {@literal {}}
+     * @see MessageFormat
      */
-    public void addMessage(@Nonnull final Level level, @Nullable final String context, @Nullable final String label,
-                           @Nonnull final String text, Object... args) {
+    public void addValidationMessage(@Nonnull final Level level, @Nullable final String context, @Nullable final String label,
+                                     @Nonnull final String text, Object... args) {
         addMessage(new Message(level, prepare(context), prepare(label), prepare(text, args)));
     }
 
@@ -364,6 +390,7 @@ public class Status {
      * @param text a text for an internationalized message
      * @param args the arguments for the text placeholders
      * @return the internationalized text
+     * @see MessageFormat
      */
     public String prepare(@Nullable String text, Object... args) {
         if (text != null) {
@@ -452,26 +479,31 @@ public class Status {
             this.logger = logger;
         }
 
+        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
         public void info(@Nonnull String text, Object... args) {
             Status.this.info(text, args);
             logger.info(text, args);
         }
 
-        public void info(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.warn(context, label, text, args);
+        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+        public void validationInfo(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
+            Status.this.validationInfo(context, label, text, args);
             logger.info(text, args);
         }
 
+        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
         public void warn(@Nonnull String text, Object... args) {
             Status.this.warn(text, args);
             logger.warn(text, args);
         }
 
-        public void warn(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.warn(context, label, text, args);
+        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+        public void validationWarn(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
+            Status.this.validationWarn(context, label, text, args);
             logger.warn(text, args);
         }
 
+        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
         public void error(@Nonnull String text, Object... args) {
             Status.this.error(text, args);
             logger.error(text, args);
@@ -482,8 +514,9 @@ public class Status {
             logger.error(prepare(text, ex.getLocalizedMessage()), ex);
         }
 
-        public void error(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.error(context, label, text, args);
+        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
+        public void validationError(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
+            Status.this.validationError(context, label, text, args);
             logger.error(text, args);
         }
     }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
+import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static javax.servlet.http.HttpServletResponse.SC_ACCEPTED;
@@ -158,9 +160,15 @@ public class Status {
 
     public Status(@Nonnull final Gson gson,
                   @Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
-        this.gson = gson;
+        this.gson = Objects.requireNonNull(gson);
         this.request = request;
         this.response = response;
+    }
+
+    /** @deprecated Constructor for gson only */
+    @Deprecated
+    public Status() {
+        this(new GsonBuilder().create(), null, null);
     }
 
     public int getStatus() {

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -427,6 +427,13 @@ public class Status {
         JsonWriter writer = ResponseUtil.getJsonWriter(response);
         response.setStatus(status);
         response.setContentType("application/json; charset=UTF-8");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Sending status {} {} {} : {}",
+                    new Object[]{status,
+                            success ? "success" : "failed",
+                            warning ? " with warning" : "",
+                            StringUtils.abbreviate(title, 256)});
+        }
         toJson(writer);
     }
 

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -8,6 +8,7 @@ import com.composum.sling.core.util.I18N;
 import com.composum.sling.core.util.ResponseUtil;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
@@ -64,7 +65,7 @@ public class Status {
 
     /** If set, added messages will be logged here. */
     @Nullable
-    protected Logger messageLogger;
+    protected transient Logger messageLogger;
     @Nullable
     protected String title;
     @Nullable
@@ -155,7 +156,7 @@ public class Status {
                 return value;
             }
         }
-        shortMessage(Level.error, errorMessage, value);
+        validationError(null, null, errorMessage, value);
         return null;
     }
 
@@ -163,14 +164,14 @@ public class Status {
                                               @Nullable final Pattern pattern, @Nonnull final String errorMessage) {
         final RequestParameter[] requestParameters = request.getRequestParameters(paramName);
         if (requestParameters == null || requestParameters.length < 1) {
-            shortMessage(Level.error, errorMessage);
+            validationError(null, null, errorMessage);
             return null;
         }
         List<String> values = new ArrayList<>();
         for (RequestParameter parameter : requestParameters) {
             String value = parameter.getString();
             if (pattern != null && !pattern.matcher(value).matches()) {
-                shortMessage(Level.error, errorMessage, value);
+                validationError(null, null, errorMessage, value);
             }
             values.add(value);
         }
@@ -329,29 +330,41 @@ public class Status {
     }
 
     /**
+     * Adds a message with minimum information.
+     *
      * @param level the message level
      * @param text  non prepared text message, may contain {@literal {}} placeholders
      * @param args  argument objects for the log like message preparation of text
+     * @return the created and added message, if you need to add more attributes
      */
-    public void shortMessage(@Nonnull final Level level, @Nonnull final String text, Object... args) {
-        addValidationMessage(level, null, null, text, args);
+    public Message shortMessage(@Nonnull final Level level, @Nonnull final String text, Object... args) {
+        return addMessage(new Message(level, text, args));
     }
 
     /**
-     * For use with validation messages: add context and label, too.
+     * For use with validation messages: add context and label, too. Validation messages are logged at level debug.
      *
      * @param level   the message level
      * @param context non prepared context key
      * @param label   non prepared aspect label (validation label)
      * @param text    non prepared text message, can contain placeholders {@literal {}}
+     * @return the created and added message, if you need to add more attributes
      * @see MessageFormat
      */
-    public void addValidationMessage(@Nonnull final Level level, @Nullable final String context, @Nullable final String label,
-                                     @Nonnull final String text, Object... args) {
-        addMessage(new Message(level, text, args).setContext(context).setLabel(label));
+    @Nonnull
+    public Message addValidationMessage(@Nonnull final Level level, @Nullable final String context,
+                                        @Nullable final String label,
+                                        @Nonnull final String text, Object... args) {
+        return addMessage(new Message(level, text, args).setContext(context).setLabel(label).setLogLevel(Level.debug));
     }
 
-    public void addMessage(@Nonnull final Message message) {
+    /**
+     * Adds the message and returns it.
+     *
+     * @return the created and added message, if you need to add more attributes
+     */
+    @Nonnull
+    public Message addMessage(@Nonnull final Message message) {
         if (messages == null) { messages = new MessageContainer(messageLogger); }
         if (message.getLevel() == Level.error) {
             status = SC_BAD_REQUEST;
@@ -367,11 +380,16 @@ public class Status {
             }
         }
         messages.add(message);
+        return message;
     }
 
     /** Writes this object as JSON using {@link Gson}. */
     public void toJson(@Nonnull final JsonWriter writer) throws IOException {
-        gson.toJson(this, getClass(), writer);
+        try {
+            gson.toJson(this, getClass(), writer);
+        } catch (JsonIOException e) {
+            throw new IOException(e);
+        }
     }
 
     /**

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -241,6 +241,15 @@ public class Status {
         shortMessage(Level.error, text, args);
     }
 
+    /**
+     * For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} .
+     * This adds the {@link Exception#getLocalizedMessage()} as message argument and logs the exception if
+     * a message logger is set.
+     */
+    public void error(@Nonnull String text, @Nonnull Throwable exception) {
+        getMessages().add(Message.error(text, exception.getLocalizedMessage()), exception);
+    }
+
     /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
     public void validationError(@Nonnull final String context, @Nonnull final String label,
                                 @Nonnull final String text, Object... args) {
@@ -397,70 +406,34 @@ public class Status {
     }
 
     /**
-     * Shortcut: if you want to log the same message to a logger as you want to present to the user - call the methods here.
-     * E.g. {@code status.withLogging(LOG).error("Some error happened in {}", path);}.
+     * Sets the logger of the {@link #getMessages()} message container to logger. Thus, new added messages will also
+     * be logged with this logger.
+     * Consider using the constructor
+     * {@link #Status(SlingHttpServletRequest, SlingHttpServletResponse, Logger)} or
+     * {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse, Logger)}.
+     *
+     * @return this in builder-style
      */
     @Nonnull
-    public StatusWithLogging withLogging(@Nonnull Logger logger) {
-        return new StatusWithLogging(logger);
+    public Status setMessageLogger(@Nullable Logger messageLogger) {
+        this.messageLogger = messageLogger;
+        return this;
     }
 
-    /** Wrapper that allows adding messages *and* logging them at the same time. Temporary object only - see {@link #withLogging(Logger)}. */
-    public class StatusWithLogging {
-
-        @Nonnull
-        private final Logger logger;
-
-        public StatusWithLogging(@Nonnull Logger logger) {
-            this.logger = logger;
-        }
-
-        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
-        public void info(@Nonnull String text, Object... args) {
-            Status.this.info(text, args);
-            logger.info(text, args);
-        }
-
-        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
-        public void validationInfo(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.validationInfo(context, label, text, args);
-            logger.info(text, args);
-        }
-
-        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
-        public void warn(@Nonnull String text, Object... args) {
-            Status.this.warn(text, args);
-            logger.warn(text, args);
-        }
-
-        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
-        public void validationWarn(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.validationWarn(context, label, text, args);
-            logger.warn(text, args);
-        }
-
-        /**
-         * For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} .
-         * If you want to log an exception stacktrace, give the exception as additional argument not used as
-         * positional parameter. If the exception is to be included as positional parameter, too,
-         * you need to transform it into a string, or it won't be replaced in the log.
-         * {@code status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
-         * }
-         */
-        public void error(@Nonnull String text, Object... args) {
-            Status.this.error(text, args);
-            logger.error(text, args);
-        }
-
-        public void error(@Nonnull String text, @Nonnull Throwable ex) {
-            Status.this.error(text, ex.getLocalizedMessage());
-            logger.error(text, ex.getLocalizedMessage(), ex);
-        }
-
-        /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */
-        public void validationError(@Nonnull String context, @Nonnull String label, @Nonnull String text, Object... args) {
-            Status.this.validationError(context, label, text, args);
-            logger.error(text, args);
-        }
+    /**
+     * Sets the logger of the {@link #getMessages()} message container to logger. Thus, new added messages will also
+     * be logged with this logger.
+     *
+     * @return this in builder-style
+     * @deprecated rather use the constructor
+     * {@link #Status(SlingHttpServletRequest, SlingHttpServletResponse, Logger)},
+     * {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse, Logger)} or {@link #setMessageLogger(Logger)}.
+     * This is kept for backwards compatibility for a while.
+     */
+    @Nonnull
+    @Deprecated
+    public Status withLogging(@Nonnull Logger logger) {
+        return setMessageLogger(logger);
     }
+
 }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -4,6 +4,7 @@ import com.composum.sling.core.logging.Message;
 import com.composum.sling.core.logging.Message.Level;
 import com.composum.sling.core.logging.MessageContainer;
 import com.composum.sling.core.logging.MessageTypeAdapterFactory;
+import com.composum.sling.core.util.I18N;
 import com.composum.sling.core.util.ResponseUtil;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -184,8 +185,15 @@ public class Status {
         return StringUtils.isNotBlank(title);
     }
 
-    public void setTitle(String title) {
-        this.title = title;
+    public void setTitle(String rawTitle) {
+        if (StringUtils.isNotBlank(rawTitle)) {
+            this.title = request != null ? I18N.get(request, rawTitle) : rawTitle;
+            if (StringUtils.isBlank(this.title)) {
+                this.title = rawTitle;
+            }
+        } else {
+            this.title = null;
+        }
     }
 
     @Nonnull
@@ -408,7 +416,7 @@ public class Status {
     /**
      * Sets the logger of the {@link #getMessages()} message container to logger. Thus, new added messages will also
      * be logged with this logger.
-     * Consider using the constructor
+     * Please consider using the constructor
      * {@link #Status(SlingHttpServletRequest, SlingHttpServletResponse, Logger)} or
      * {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse, Logger)}.
      *
@@ -427,7 +435,8 @@ public class Status {
      * @return this in builder-style
      * @deprecated rather use the constructor
      * {@link #Status(SlingHttpServletRequest, SlingHttpServletResponse, Logger)},
-     * {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse, Logger)} or {@link #setMessageLogger(Logger)}.
+     * {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse, Logger)}
+     * or, if need be, {@link #setMessageLogger(Logger)}.
      * This is kept for backwards compatibility for a while.
      */
     @Nonnull

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -7,6 +7,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -14,12 +15,13 @@ import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
-import java.text.DecimalFormat;
+import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,6 +45,8 @@ import static org.apache.sling.api.resource.ResourceUtil.isSyntheticResource;
  * list - it's probably easier to extend Status and have attributes with the specific types needed.)
  */
 public class Status {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Status.class);
 
     public static final String STATUS = "status";
     public static final String SUCCESS = "success";
@@ -455,6 +459,27 @@ public class Status {
         gson.toJson(this, getClass(), writer);
     }
 
+    /**
+     * Returns the JSON representation of this status as String, primarily for logging.
+     * Usable for logging: never throws up even if JSON generation fails, though it's
+     * obviously lacking data then.
+     */
+    @Nonnull
+    public String getJsonString() {
+        try (StringWriter statusString = new StringWriter()) {
+            toJson(new JsonWriter(statusString));
+            return statusString.toString();
+        } catch (IOException | RuntimeException e) {
+            LOG.error("Could not create JSON", e);
+            try { // since this is primarily for logging, we try this as last resort.
+                return ReflectionToStringBuilder.reflectionToString(this);
+            } catch (RuntimeException e1) {
+                LOG.error("Could not even create some representation via reflection. Giving up.", e1);
+                return super.toString();
+            }
+        }
+    }
+
     /** Serializes the status message and writes it in the response, using {@link #getStatus()} as HTTP status. */
     public void sendJson() throws IOException {
         sendJson(getStatus());
@@ -511,7 +536,14 @@ public class Status {
             logger.warn(text, args);
         }
 
-        /** For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} . */
+        /**
+         * For the meaning of arguments - compare {@link #shortMessage(Level, String, Object...)} .
+         * If you want to log an exception stacktrace, give the exception as additional argument not used as
+         * positional parameter. If the exception is to be included as positional parameter, too,
+         * you need to transform it into a string, or it won't be replaced in the log.
+         * <code>status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
+         * </code>
+         */
         public void error(@Nonnull String text, Object... args) {
             Status.this.error(text, args);
             logger.error(text, args);

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -126,10 +126,14 @@ public class Status {
     protected boolean success = true;
     protected boolean warning = false;
 
+    @Nullable
     protected String title;
-    protected final List<Message> messages;
-    protected final Map<String, Map<String, Object>> data;
-    protected final Map<String, List<Map<String, Object>>> list;
+    @Nullable
+    protected List<Message> messages;
+    @Nullable
+    protected Map<String, Map<String, Object>> data;
+    @Nullable
+    protected Map<String, List<Map<String, Object>>> list;
 
     public Status(@Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
         this(new GsonBuilder().create(), request, response);
@@ -140,9 +144,6 @@ public class Status {
         this.gson = gson;
         this.request = request;
         this.response = response;
-        data = new HashMap<>();
-        list = new HashMap<>();
-        messages = new ArrayList<>();
     }
 
     public int getStatus() {
@@ -257,6 +258,7 @@ public class Status {
      */
     @Nonnull
     public Map<String, Object> data(@Nonnull final String name) {
+        if (data == null) { data = new LinkedHashMap<>();}
         Map<String, Object> object = data.get(name);
         if (object == null) {
             object = new LinkedHashMap<>();
@@ -296,6 +298,7 @@ public class Status {
      */
     @Nonnull
     public List<Map<String, Object>> list(@Nonnull final String name) {
+        if (list == null) { list = new LinkedHashMap<>(); }
         List<Map<String, Object>> object = list.get(name);
         if (object == null) {
             object = new ArrayList<>();
@@ -340,6 +343,7 @@ public class Status {
     }
 
     public void addMessage(@Nonnull final Message message) {
+        if (messages == null) { messages = new ArrayList<>(); }
         if (message.level == Level.error) {
             status = SC_BAD_REQUEST;
             success = false;

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -1,7 +1,9 @@
 package com.composum.sling.core.servlet;
 
-import com.composum.sling.core.util.I18N;
-import com.composum.sling.core.util.LoggerFormat;
+import com.composum.sling.core.logging.Message;
+import com.composum.sling.core.logging.Message.Level;
+import com.composum.sling.core.logging.MessageContainer;
+import com.composum.sling.core.logging.MessageTypeAdapterFactory;
 import com.composum.sling.core.util.ResponseUtil;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -20,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.Reader;
 import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static javax.servlet.http.HttpServletResponse.SC_ACCEPTED;
@@ -48,98 +50,8 @@ public class Status {
 
     private static final Logger LOG = LoggerFactory.getLogger(Status.class);
 
-    public static final String STATUS = "status";
-    public static final String SUCCESS = "success";
-    public static final String WARNING = "warning";
-
-    public static final String TITLE = "title";
-    public static final String MESSAGES = "messages";
-    public static final String LEVEL = "level";
-    public static final String CONTEXT = "context";
-    public static final String LABEL = "label";
-    public static final String TEXT = "text";
-    public static final String HINT = "hint";
-
+    /** Constant for often used argument for {@link #data(String)}. */
     public static final String DATA = "data";
-
-    public static final String BOOTSTRAP_ERROR = "danger";
-
-    public enum Level {
-        info, warn, error;
-
-        @Nonnull
-        public static Level levelOf(@Nonnull String name) {
-            if (BOOTSTRAP_ERROR.equalsIgnoreCase(name)) {
-                name = error.name();
-            }
-            return valueOf(name);
-        }
-    }
-
-    public class Message {
-
-        @Nonnull
-        public final Level level;
-
-        /** In validation messages: context of the validation, for instance the dialog tab. */
-        @Nullable
-        public final String context;
-
-        /** In validation messages: label of the field which the message is about. */
-        @Nullable
-        public final String label;
-
-        /** The text of the message, can contain {@literal {}} placeholders. */
-        @Nonnull
-        public final String text;
-
-        /** @param text The text of the message, can contain {@literal {}} placeholders. */
-        public Message(@Nonnull final Level level, @Nonnull final String text) {
-            this(level, null, null, text);
-        }
-
-        /**
-         * @param context In validation messages: context of the validation, for instance the dialog tab.
-         * @param label   In validation messages: label of the field which the message is about.
-         * @param text    The text of the message, can contain {@literal {}} placeholders.
-         */
-        public Message(@Nonnull final Level level,
-                       @Nullable final String context, @Nullable final String label,
-                       @Nonnull final String text) {
-            this.level = level;
-            this.context = context;
-            this.label = label;
-            this.text = text;
-        }
-
-        /**
-         * the 'translate' constructor
-         */
-        public Message(Map<String, Object> data) {
-            Object value;
-            Object hint = data.get(HINT);
-            level = (value = data.get(LEVEL)) != null ? Level.levelOf(value.toString()) : Level.info;
-            context = (value = data.get(CONTEXT)) != null ? prepare(value.toString()) : null;
-            label = (value = data.get(LABEL)) != null ? prepare(value.toString()) : null;
-            text = (value = data.get(TEXT)) != null
-                    ? (hint != null ? prepare(value.toString(), hint) : prepare(value.toString()))
-                    : null;
-        }
-
-        @SuppressWarnings("Duplicates")
-        public void toJson(JsonWriter writer) throws IOException {
-            writer.beginObject();
-            writer.name(LEVEL).value(level.name());
-            if (StringUtils.isNotBlank(context)) {
-                writer.name(CONTEXT).value(context);
-            }
-            if (StringUtils.isNotBlank(label)) {
-                writer.name(LABEL).value(label);
-            }
-            writer.name(TEXT).value(text);
-            writer.endObject();
-        }
-    }
 
     protected transient final Gson gson;
     protected transient final SlingHttpServletRequest request;
@@ -149,19 +61,45 @@ public class Status {
     protected boolean success = true;
     protected boolean warning = false;
 
+    /** If set, added messages will be logged here. */
+    @Nullable
+    protected Logger messageLogger;
     @Nullable
     protected String title;
     @Nullable
-    protected List<Message> messages;
+    protected MessageContainer messages;
     @Nullable
     protected Map<String, Map<String, Object>> data;
     @Nullable
     protected Map<String, List<Map<String, Object>>> list;
 
-    public Status(@Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
-        this(new GsonBuilder().create(), request, response);
+    public Status(@Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response,
+                  @Nullable Logger messageLogger) {
+        this(new GsonBuilder(), request, response, messageLogger);
     }
 
+    public Status(@Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
+        this(new GsonBuilder(), request, response, null);
+    }
+
+    /** Construction */
+    public Status(@Nonnull final GsonBuilder gsonBuilder,
+                  @Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response,
+                  @Nullable Logger messageLogger) {
+        this.gson = initGson(Objects.requireNonNull(gsonBuilder), () -> request).create();
+        this.request = request;
+        this.response = response;
+        this.messageLogger = messageLogger;
+    }
+
+    /**
+     * Construct with a specific Gson instance. CAUTION: you need to have called
+     * {@link #initGson(GsonBuilder, SlingHttpServletRequest)} for proper message translation.
+     * Perhaps rather use {@link #Status(GsonBuilder, SlingHttpServletRequest, SlingHttpServletResponse)}.
+     *
+     * @deprecated since it's dangerous to forget {@link #initGson(GsonBuilder, SlingHttpServletRequest)}.
+     */
+    @Deprecated
     public Status(@Nonnull final Gson gson,
                   @Nullable final SlingHttpServletRequest request, @Nullable final SlingHttpServletResponse response) {
         this.gson = Objects.requireNonNull(gson);
@@ -169,10 +107,24 @@ public class Status {
         this.response = response;
     }
 
-    /** @deprecated Constructor for gson only */
+    /** @deprecated Constructor for deserialization with gson only */
     @Deprecated
     public Status() {
         this(new GsonBuilder().create(), null, null);
+    }
+
+    /**
+     * Registers a type adapter for the JSON serialization of {@link Message} and {@link MessageContainer} that
+     * performs i18n according to the given request. If there is no request, we can skip this step as these classes are
+     * annotated with {@link com.google.gson.annotations.JsonAdapter}.
+     */
+    @Nonnull
+    public static GsonBuilder initGson(@Nonnull GsonBuilder gsonBuilder,
+                                       @Nonnull Supplier<SlingHttpServletRequest> requestProvider) {
+        if (requestProvider != null) {
+            return gsonBuilder.registerTypeAdapterFactory(new MessageTypeAdapterFactory(requestProvider));
+        }
+        return gsonBuilder;
     }
 
     public int getStatus() {
@@ -225,7 +177,7 @@ public class Status {
     }
 
     public String getTitle() {
-        return hasTitle() ? title : prepare("Result");
+        return title;
     }
 
     public boolean hasTitle() {
@@ -233,7 +185,13 @@ public class Status {
     }
 
     public void setTitle(String title) {
-        this.title = title != null ? prepare(title) : null;
+        this.title = title;
+    }
+
+    @Nonnull
+    public MessageContainer getMessages() {
+        if (messages == null) { messages = new MessageContainer(messageLogger); }
+        return messages;
     }
 
     public boolean isValid() {
@@ -246,6 +204,10 @@ public class Status {
 
     public boolean isWarning() {
         return warning;
+    }
+
+    public void setWarning(boolean value) {
+        this.warning = value;
     }
 
     public boolean isError() {
@@ -294,11 +256,7 @@ public class Status {
     @Nonnull
     public Map<String, Object> data(@Nonnull final String name) {
         if (data == null) { data = new LinkedHashMap<>();}
-        Map<String, Object> object = data.get(name);
-        if (object == null) {
-            object = new LinkedHashMap<>();
-            data.put(name, object);
-        }
+        Map<String, Object> object = data.computeIfAbsent(name, k -> new LinkedHashMap<>());
         return object;
     }
 
@@ -334,11 +292,7 @@ public class Status {
     @Nonnull
     public List<Map<String, Object>> list(@Nonnull final String name) {
         if (list == null) { list = new LinkedHashMap<>(); }
-        List<Map<String, Object>> object = list.get(name);
-        if (object == null) {
-            object = new ArrayList<>();
-            list.put(name, object);
-        }
+        List<Map<String, Object>> object = list.computeIfAbsent(name, k -> new ArrayList<>());
         return object;
     }
 
@@ -363,7 +317,7 @@ public class Status {
      * @param args  argument objects for the log like message preparation of text
      */
     public void shortMessage(@Nonnull final Level level, @Nonnull final String text, Object... args) {
-        addValidationMessage(level, null, null, prepare(text, args));
+        addValidationMessage(level, null, null, text, args);
     }
 
     /**
@@ -377,18 +331,18 @@ public class Status {
      */
     public void addValidationMessage(@Nonnull final Level level, @Nullable final String context, @Nullable final String label,
                                      @Nonnull final String text, Object... args) {
-        addMessage(new Message(level, prepare(context), prepare(label), prepare(text, args)));
+        addMessage(new Message(level, text, args).setContext(context).setLabel(label));
     }
 
     public void addMessage(@Nonnull final Message message) {
-        if (messages == null) { messages = new ArrayList<>(); }
-        if (message.level == Level.error) {
+        if (messages == null) { messages = new MessageContainer(messageLogger); }
+        if (message.getLevel() == Level.error) {
             status = SC_BAD_REQUEST;
             success = false;
             if (!hasTitle()) {
                 setTitle("Error");
             }
-        } else if (message.level == Level.warn && status == SC_OK) {
+        } else if (message.getLevel() == Level.warn && status == SC_OK) {
             status = SC_ACCEPTED; // 202 - accepted but there is a warning
             warning = true;
             if (!hasTitle()) {
@@ -396,62 +350,6 @@ public class Status {
             }
         }
         messages.add(message);
-    }
-
-    /**
-     * @param text a text for an internationalized message
-     * @param args the arguments for the text placeholders
-     * @return the internationalized text
-     * @see MessageFormat
-     */
-    public String prepare(@Nullable String text, Object... args) {
-        if (text != null) {
-            text = I18N.get(request, text);
-            if (args != null && args.length > 0) {
-                text = LoggerFormat.format(text, args);
-            }
-        }
-        return text;
-    }
-
-    @SuppressWarnings("unchecked")
-    public void translate(@Nonnull final Reader reader) {
-        Map<String, Object> data = gson.fromJson(reader, Map.class);
-        Object value;
-        if ((value = data.get(TITLE)) != null) {
-            setTitle(prepare(value.toString()));
-        }
-        if ((value = data.get(SUCCESS)) instanceof Boolean) {
-            success = (Boolean) value;
-            if (success) {
-                status = SC_OK;
-            } else {
-                status = SC_BAD_REQUEST;
-                if (!hasTitle()) {
-                    setTitle("Error");
-                }
-            }
-        }
-        if ((value = data.get(WARNING)) instanceof Boolean) {
-            warning = (Boolean) value;
-            if (success) {
-                status = SC_ACCEPTED;
-            }
-            if (!hasTitle()) {
-                setTitle("Warning");
-            }
-        }
-        if ((value = data.get(STATUS)) != null) {
-            setStatus(value instanceof Integer ? (Integer) value : Integer.parseInt(value.toString()));
-        }
-        if ((value = data.get(MESSAGES)) instanceof Collection) {
-            for (Object val : ((Collection<?>) value)) {
-                if (val instanceof Map) {
-                    //noinspection rawtypes
-                    addMessage(new Message((Map) val));
-                }
-            }
-        }
     }
 
     /** Writes this object as JSON using {@link Gson}. */
@@ -493,9 +391,14 @@ public class Status {
         toJson(writer);
     }
 
+    @Nonnull
+    public Gson getGson() {
+        return gson;
+    }
+
     /**
      * Shortcut: if you want to log the same message to a logger as you want to present to the user - call the methods here.
-     * E.g. <code>status.withLogging(LOG).error("Some error happened in {}", path);</code>.
+     * E.g. {@code status.withLogging(LOG).error("Some error happened in {}", path);}.
      */
     @Nonnull
     public StatusWithLogging withLogging(@Nonnull Logger logger) {
@@ -541,8 +444,8 @@ public class Status {
          * If you want to log an exception stacktrace, give the exception as additional argument not used as
          * positional parameter. If the exception is to be included as positional parameter, too,
          * you need to transform it into a string, or it won't be replaced in the log.
-         * <code>status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
-         * </code>
+         * {@code status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
+         * }
          */
         public void error(@Nonnull String text, Object... args) {
             Status.this.error(text, args);
@@ -551,7 +454,7 @@ public class Status {
 
         public void error(@Nonnull String text, @Nonnull Throwable ex) {
             Status.this.error(text, ex.getLocalizedMessage());
-            logger.error(prepare(text, ex.getLocalizedMessage()), ex);
+            logger.error(text, ex.getLocalizedMessage(), ex);
         }
 
         /** For the meaning of arguments - compare {@link #addValidationMessage(Level, String, String, String, Object...)} . */

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/Status.java
@@ -33,7 +33,11 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.sling.api.resource.ResourceUtil.isSyntheticResource;
 
 /**
- * the standardised answer object of a servlet request to fill the response output
+ * The standardised answer object of a servlet request to fill the response output.
+ * It allows adding generic objects and lists with the {@link #data(String)} / {@link #list(String)} methods.
+ * Can be serialized and deserialized with {@link Gson}, so it is possible to extend this and add your own attributes, too.
+ * (Caution: for deserializing it with Gson you might run into trouble if you put arbitrary objects into the data /
+ * list - it's probably easier to extend Status and have attributes with the specific types needed.)
  */
 public class Status {
 
@@ -114,9 +118,9 @@ public class Status {
         }
     }
 
-    protected final Gson gson;
-    protected final SlingHttpServletRequest request;
-    protected final SlingHttpServletResponse response;
+    protected transient final Gson gson;
+    protected transient final SlingHttpServletRequest request;
+    protected transient final SlingHttpServletResponse response;
 
     protected int status = SC_OK;
     protected boolean success = true;
@@ -246,18 +250,26 @@ public class Status {
     }
 
     /**
+     * Returns a map that is saved with the given name in the data section of the Status, creating it if necessary.
+     *
      * @param name the key of the data element to insert in the status response
-     * @return a new Map for the data values of the added status object
+     * @return a Map for the data values of the added status object, created if neccesary.
      */
     @Nonnull
     public Map<String, Object> data(@Nonnull final String name) {
-        Map<String, Object> object = new LinkedHashMap<>();
-        data.put(name, object);
+        Map<String, Object> object = data.get(name);
+        if (object == null) {
+            object = new LinkedHashMap<>();
+            data.put(name, object);
+        }
         return object;
     }
 
     /**
+     * Adds information about resource as {@link #data(String)} object.
+     *
      * @param name the key of the data element to insert in the status response
+     * @see #reference(Map, Resource)
      */
     public void reference(@Nonnull final String name, Resource resource) {
         Map<String, Object> object = data(name);
@@ -265,7 +277,8 @@ public class Status {
     }
 
     /**
-     *
+     * Adds general information about the resource into the object: name, path, type (Sling resourcetype),
+     * prim (primary type), synthetic (whether it is a synthetic resource).
      */
     public void reference(Map<String, Object> object, Resource resource) {
         object.put("name", resource.getName());
@@ -276,17 +289,25 @@ public class Status {
     }
 
     /**
+     * Returns the list for the given name, creating it if neccesary.
+     *
      * @param name the key of the data element to insert in the status response
      * @return a new list of Map items for the data values of the added status object
      */
     @Nonnull
     public List<Map<String, Object>> list(@Nonnull final String name) {
-        List<Map<String, Object>> object = new ArrayList<>();
-        list.put(name, object);
+        List<Map<String, Object>> object = list.get(name);
+        if (object == null) {
+            object = new ArrayList<>();
+            list.put(name, object);
+        }
         return object;
     }
 
     /**
+     * Adds a list of resources in a request with common information. If there was already a list with that name,
+     * the items are added to it.
+     *
      * @param name the key of the data element to insert in the status response
      */
     public void list(@Nonnull final String name, Collection<Resource> items) {
@@ -390,40 +411,9 @@ public class Status {
         }
     }
 
+    /** Writes this object as JSON using {@link Gson}. */
     public void toJson(@Nonnull final JsonWriter writer) throws IOException {
-        writer.beginObject();
-        writer.name(STATUS).value(getStatus());
-        writer.name(SUCCESS).value(isSuccess());
-        writer.name(WARNING).value(isWarning());
-        writer.name(TITLE).value(getTitle());
-        writer.name(MESSAGES).beginArray();
-        for (Message message : messages) {
-            message.toJson(writer);
-        }
-        writer.endArray();
-        for (Map.Entry<String, Map<String, Object>> entry : data.entrySet()) {
-            writer.name(entry.getKey());
-            gson.toJson(entry.getValue(), Map.class, writer);
-        }
-        for (Map.Entry<String, List<Map<String, Object>>> entry : list.entrySet()) {
-            writer.name(entry.getKey());
-            List<Map<String, Object>> value = entry.getValue();
-            writer.beginArray();
-            for (Map<String, Object> item : value) {
-                gson.toJson(item, Map.class, writer);
-            }
-            writer.endArray();
-        }
-        writeAdditionalAttributes(writer);
-        writer.endObject();
-    }
-
-    /**
-     * Extension-hook to include stuff that does not fit the serialization scheme for {@link #data(String)} and
-     * {@link #list(String)}. Please use sparingly, if at all.
-     */
-    protected void writeAdditionalAttributes(@Nonnull final JsonWriter writer) throws IOException {
-        // empty
+        gson.toJson(this, getClass(), writer);
     }
 
     /** Serializes the status message and writes it in the response, using {@link #getStatus()} as HTTP status. */

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
@@ -2,6 +2,7 @@ package com.composum.sling.core.servlet;
 
 import com.composum.sling.core.CoreConfiguration;
 import com.composum.sling.core.ResourceHandle;
+import com.composum.sling.core.logging.Message;
 import com.composum.sling.core.service.TranslationService;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
@@ -12,8 +13,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 
+import static javax.servlet.http.HttpServletResponse.SC_ACCEPTED;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 @SlingServlet(
@@ -23,6 +29,22 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 public class TranslationServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(TranslationServlet.class);
+
+    public static final String STATUS = "status";
+    public static final String SUCCESS = "success";
+    public static final String WARNING = "warning";
+
+    public static final String TITLE = "title";
+    public static final String MESSAGES = "messages";
+    public static final String LEVEL = "level";
+    public static final String CONTEXT = "context";
+    public static final String LABEL = "label";
+    public static final String TEXT = "text";
+    public static final String HINT = "hint";
+
+    public static final String DATA = "data";
+
+    public static final String BOOTSTRAP_ERROR = "danger";
 
     public enum Extension {json}
 
@@ -54,7 +76,7 @@ public class TranslationServlet extends AbstractServiceServlet {
     }
 
     /**
-     * Gets a part of the named temp. outputfile.
+     * Translates (i18n) all strings in a given JSON.
      */
     protected class TranslateObject implements ServletOperation {
 
@@ -70,7 +92,7 @@ public class TranslationServlet extends AbstractServiceServlet {
     }
 
     /**
-     * Gets a part of the named temp. outputfile.
+     * Translates (i18n) status-like information into a Status.
      */
     protected class TranslateStatus implements ServletOperation {
 
@@ -80,8 +102,63 @@ public class TranslationServlet extends AbstractServiceServlet {
                          @Nonnull final ResourceHandle resource)
                 throws IOException {
             Status status = new Status(request, response);
-            status.translate(request.getReader());
-            status.sendJson(SC_OK);
+            readFrom(request.getReader(), status);
+            status.sendJson(SC_OK); // the normal i18n of Status and its Messages takes care of the translation.
         }
+
+        /** Parses the request format. */
+        protected void readFrom(BufferedReader reader, Status status) {
+            Map<String, Object> data = status.getGson().fromJson(reader, Map.class);
+            Object value;
+            if ((value = data.get(TITLE)) != null) {
+                status.setTitle(value.toString());
+            }
+            boolean success = false;
+            if ((value = data.get(SUCCESS)) instanceof Boolean) {
+                success = (Boolean) value;
+                if (success) {
+                    status.setStatus(SC_OK);
+                } else {
+                    status.setStatus(SC_BAD_REQUEST);
+                    if (!status.hasTitle()) {
+                        status.setTitle("Error");
+                    }
+                }
+            }
+            if ((value = data.get(WARNING)) instanceof Boolean) {
+                status.setWarning((Boolean) value);
+                if (success) {
+                    status.setStatus(SC_ACCEPTED);
+                }
+                if (!status.hasTitle()) {
+                    status.setTitle("Warning");
+                }
+            }
+            if ((value = data.get(STATUS)) != null) {
+                status.setStatus(value instanceof Integer ? (Integer) value : Integer.parseInt(value.toString()));
+            }
+            if ((value = data.get(MESSAGES)) instanceof Collection) {
+                for (Object val : ((Collection<?>) value)) {
+                    if (val instanceof Map) {
+                        //noinspection rawtypes
+                        status.addMessage(parseMessage((Map) val));
+                    }
+                }
+            }
+
+        }
+
+        /** Reads a message from the input format. */
+        protected Message parseMessage(Map<String, Object> data) {
+            Object value;
+            Object hint = data.get(HINT);
+            Message.Level level = (value = data.get(LEVEL)) != null ? Message.Level.levelOf(value.toString()) : Message.Level.info;
+            String context = (value = data.get(CONTEXT)) != null ? value.toString() : null;
+            String label = (value = data.get(LABEL)) != null ? value.toString() : null;
+            String text = (value = data.get(TEXT)) != null ? value.toString() : null;
+            Message message = new Message(level, text, hint).setContext(context).setLabel(label);
+            return message;
+        }
+
     }
 }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
@@ -152,12 +152,22 @@ public class TranslationServlet extends AbstractServiceServlet {
         protected Message parseMessage(Map<String, Object> data) {
             Object value;
             Object hint = data.get(HINT);
-            Message.Level level = (value = data.get(LEVEL)) != null ? Message.Level.levelOf(value.toString()) : Message.Level.info;
+            Message.Level level = (value = data.get(LEVEL)) != null ? levelOf(value.toString()) : Message.Level.info;
             String context = (value = data.get(CONTEXT)) != null ? value.toString() : null;
             String label = (value = data.get(LABEL)) != null ? value.toString() : null;
             String text = (value = data.get(TEXT)) != null ? value.toString() : null;
             Message message = new Message(level, text, hint).setContext(context).setLabel(label);
             return message;
+        }
+
+        public static final String BOOTSTRAP_ERROR = "danger";
+
+        @Nonnull
+        public Message.Level levelOf(@Nonnull String name) {
+            if (BOOTSTRAP_ERROR.equalsIgnoreCase(name)) {
+                name = Message.Level.error.name();
+            }
+            return Message.Level.valueOf(name);
         }
 
     }

--- a/sling/core/commons/src/main/java/com/composum/sling/core/util/I18N.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/util/I18N.java
@@ -1,10 +1,12 @@
 package com.composum.sling.core.util;
 
 import com.composum.sling.core.RequestBundle;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.util.MissingResourceException;
 
 /**
@@ -14,10 +16,15 @@ public class I18N {
 
     private static final Logger LOG = LoggerFactory.getLogger(I18N.class);
 
-    public static String get(SlingHttpServletRequest request, String text) {
+    public static String get(@Nonnull SlingHttpServletRequest request, String text) {
         String translated = null;
         try {
             translated = RequestBundle.get(request).getString(text);
+            if (StringUtils.isBlank(translated)) {
+                LOG.warn("Suspicious translation to blank string ignored for '{}' locale {}", text,
+                        request.getLocale());
+                translated = null;
+            }
         } catch (MissingResourceException mrex) {
             if (LOG.isInfoEnabled()) {
                 LOG.info(mrex.toString());

--- a/sling/core/commons/src/main/java/com/composum/sling/core/util/SlingResourceUtil.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/util/SlingResourceUtil.java
@@ -28,10 +28,12 @@ public class SlingResourceUtil {
     /**
      * Returns the shortest relative path that leads from a node to another node.
      * Postcondition: <code>ResourceUtil.normalize(node + "/" + result), is(ResourceUtil.normalize(other))</code>.
+     * In most cases  {@link #appendPaths(String, String)}(node, result) will return {other}. )}
      *
      * @param node  the parent
-     * @param other a path of a child of parent
-     * @return the path from which other can be read from node - e.g. with {@link org.apache.sling.api.resource.Resource#getChild(String)}. If node and other are the same, this is empty.
+     * @param other a path of a child of parent / parent itself
+     * @return the (relative) path from which other can be read from node - e.g. with
+     * {@link org.apache.sling.api.resource.Resource#getChild(String)}. If node and other are the same, this is empty.
      * @throws IllegalArgumentException in those cases where there is no sensible answer: one of the paths is empty or one absolute and one relative path
      */
     public static String relativePath(@Nonnull String node, @Nonnull String other) {

--- a/sling/core/commons/src/main/java/com/composum/sling/core/util/SlingResourceUtil.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/util/SlingResourceUtil.java
@@ -5,6 +5,7 @@ import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,6 +15,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A set of utility functions related to the handling of Sling Resources, without going down to JCR specifics.
@@ -129,39 +132,25 @@ public class SlingResourceUtil {
      * Returns an iterator that goes through all descendants of a resource, parents come before their children.
      *
      * @param resource a resource or null
-     * @return an iterable running through the descendants, not null
+     * @return an iterable running through the resource and it's descendants, not null
      */
     @Nonnull
     public static Iterable<Resource> descendants(@Nullable final Resource resource) {
-        // this is awful because we are stuck at Java 7 for now. With Java 8 Streams this is way easier.
-        if (resource == null) { return Collections.emptyList(); }
-        return new Iterable<Resource>() {
-            @Nonnull
-            @SuppressWarnings("unchecked")
-            @Override
-            public Iterator<Resource> iterator() {
-                Transformer descendantsTransformer = new Transformer() {
-                    @Override
-                    public Object transform(Object input) {
-                        if (input instanceof Resource) {
-                            return IteratorUtils.chainedIterator(
-                                    // we wrap the resource into Object[] so that it doesn't get its children read again
-                                    IteratorUtils.singletonIterator(new Object[]{input}),
-                                    ((Resource) input).listChildren());
-                        }
-                        return input;
-                    }
-                };
-                return IteratorUtils.transformedIterator(IteratorUtils.objectGraphIterator(resource, descendantsTransformer),
-                        new Transformer() {
-                            @Override
-                            public Object transform(Object input) {
-                                return ((Object[]) input)[0];
-                            }
-                        });
-            }
+        return () -> descendantsStream(resource).iterator();
+    }
 
-        };
+    /**
+     * Returns a stream that goes through all descendants of a resource, parents come before their children.
+     *
+     * @param resource a resource or null
+     * @return a stream running through the resource and it's the descendants, not null
+     */
+    @Nonnull
+    public static Stream<Resource> descendantsStream(@Nullable Resource resource) {
+        if (resource == null) { return Stream.empty(); }
+        return Stream.concat(Stream.of(resource),
+                StreamSupport.stream(resource.getChildren().spliterator(), false)
+                        .flatMap(SlingResourceUtil::descendantsStream));
     }
 
     /**
@@ -207,6 +196,24 @@ public class SlingResourceUtil {
                 }
                 if (result == null) { break; } // no common parents
             }
+        }
+        return result;
+    }
+
+    /**
+     * Retrieves the first parent (including path itself) that actually exists.
+     *
+     * @param path an absolute path
+     * @return path or the longest path parent to path that exists in resolver. Null if path
+     * is empty.
+     */
+    @Nullable
+    public static Resource getFirstExistingParent(@Nullable ResourceResolver resolver, @Nullable String path) {
+        String searchedPath = path;
+        Resource result = StringUtils.isNotBlank(searchedPath) ? resolver.getResource(searchedPath) : null;
+        while (result == null && StringUtils.isNotBlank(searchedPath)) {
+            searchedPath = ResourceUtil.getParent(searchedPath);
+            result = resolver.getResource(searchedPath);
         }
         return result;
     }

--- a/sling/core/commons/src/test/java/com/composum/sling/core/logging/MessageContainerTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/logging/MessageContainerTest.java
@@ -37,7 +37,7 @@ public class MessageContainerTest {
         container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17))
                 .add(new Message(null, "Minimal message"))
                 .add(new Message(Message.Level.info, "Message {} with details", 3)
-                        .addDetail(new Message(Message.Level.debug, "Detail {}", 1))
+                        .addDetail(new Message(Message.Level.debug, "Detail {}", 1).setLogLevel(Message.Level.warn))
                         .addDetail(new Message(Message.Level.info, "Detail {}", 2))
                 );
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -73,6 +73,7 @@ public class MessageContainerTest {
                 "    \"details\": [\n" +
                 "      {\n" +
                 "        \"level\": \"debug\",\n" +
+                "        \"logLevel\": \"warn\",\n" +
                 "        \"text\": \"Detail 1\",\n" +
                 "        \"rawText\": \"Detail {}\",\n" +
                 "        \"arguments\": [\n" +
@@ -103,7 +104,7 @@ public class MessageContainerTest {
                 "Minimal message\n" +
                 "Message 3 with details\n" +
                 "    Details:\n" +
-                "    debug: Detail 1\n" +
+                "    debug(warn): Detail 1\n" +
                 "    Detail 2");
     }
 

--- a/sling/core/commons/src/test/java/com/composum/sling/core/logging/MessageContainerTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/logging/MessageContainerTest.java
@@ -22,14 +22,14 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.is;
 
 /** Tests for {@link MessageContainer} and {@link Message}. */
-public class TestMessageContainer {
+public class MessageContainerTest {
 
     public static final String TIMESTAMP_REGEX = "157[0-9]{10}";
 
     @Rule
     public ErrorCollector ec = new ErrorCollector();
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestMessageContainer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MessageContainerTest.class);
 
     @Test
     public void jsonizeAndBack() {

--- a/sling/core/commons/src/test/java/com/composum/sling/core/logging/TestMessageContainer.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/logging/TestMessageContainer.java
@@ -50,8 +50,8 @@ public class TestMessageContainer {
         compare(json, "[\n" +
                 "  {\n" +
                 "    \"level\": \"warn\",\n" +
-                "    \"message\": \"Some problem with foo number 17\",\n" +
-                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
+                "    \"text\": \"Some problem with foo number 17\",\n" +
+                "    \"rawText\": \"Some problem with {} number {}\",\n" +
                 "    \"arguments\": [\n" +
                 "      \"foo\",\n" +
                 "      17\n" +
@@ -59,22 +59,22 @@ public class TestMessageContainer {
                 "    \"timestamp\": <timestamp>\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"message\": \"Minimal message\",\n" +
-                "    \"rawMessage\": \"Minimal message\",\n" +
+                "    \"text\": \"Minimal message\",\n" +
+                "    \"rawText\": \"Minimal message\",\n" +
                 "    \"timestamp\": <timestamp>\n" +
                 "  },\n" +
                 "  {\n" +
                 "    \"level\": \"info\",\n" +
-                "    \"message\": \"Message 3 with details\",\n" +
-                "    \"rawMessage\": \"Message {} with details\",\n" +
+                "    \"text\": \"Message 3 with details\",\n" +
+                "    \"rawText\": \"Message {} with details\",\n" +
                 "    \"arguments\": [\n" +
                 "      3\n" +
                 "    ],\n" +
                 "    \"details\": [\n" +
                 "      {\n" +
                 "        \"level\": \"debug\",\n" +
-                "        \"message\": \"Detail 1\",\n" +
-                "        \"rawMessage\": \"Detail {}\",\n" +
+                "        \"text\": \"Detail 1\",\n" +
+                "        \"rawText\": \"Detail {}\",\n" +
                 "        \"arguments\": [\n" +
                 "          1\n" +
                 "        ],\n" +
@@ -82,8 +82,8 @@ public class TestMessageContainer {
                 "      },\n" +
                 "      {\n" +
                 "        \"level\": \"info\",\n" +
-                "        \"message\": \"Detail 2\",\n" +
-                "        \"rawMessage\": \"Detail {}\",\n" +
+                "        \"text\": \"Detail 2\",\n" +
+                "        \"rawText\": \"Detail {}\",\n" +
                 "        \"arguments\": [\n" +
                 "          2\n" +
                 "        ],\n" +
@@ -116,31 +116,6 @@ public class TestMessageContainer {
 
         MessageContainer container = new MessageContainer(LOG);
         container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17));
-        container.i18n(request);
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        compare(gson.toJson(container), "[\n" +
-                "  {\n" +
-                "    \"level\": \"warn\",\n" +
-                "    \"message\": \"Ein Problem mit foo Nummer 17\",\n" +
-                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
-                "    \"arguments\": [\n" +
-                "      \"foo\",\n" +
-                "      17\n" +
-                "    ],\n" +
-                "    \"timestamp\": <timestamp>\n" +
-                "  }\n" +
-                "]");
-    }
-
-    @Test
-    public void i18nViaTypeAdapterFactory() throws IOException {
-        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
-        ResourceBundle bundle = new PropertyResourceBundle(new StringReader(
-                "Some\\ problem\\ with\\ {}\\ number\\ {}: Ein Problem mit {} Nummer {}"));
-        Mockito.when(request.getResourceBundle(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(bundle);
-
-        MessageContainer container = new MessageContainer(LOG);
-        container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17));
         // not: container.i18n(request);
 
         Gson gson = new GsonBuilder().setPrettyPrinting()
@@ -150,8 +125,8 @@ public class TestMessageContainer {
         compare(gson.toJson(container), "[\n" +
                 "  {\n" +
                 "    \"level\": \"warn\",\n" +
-                "    \"message\": \"Ein Problem mit foo Nummer 17\",\n" +
-                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
+                "    \"text\": \"Ein Problem mit foo Nummer 17\",\n" +
+                "    \"rawText\": \"Some problem with {} number {}\",\n" +
                 "    \"arguments\": [\n" +
                 "      \"foo\",\n" +
                 "      17\n" +
@@ -221,15 +196,15 @@ public class TestMessageContainer {
                 "  \"messages\": [\n" +
                 "    {\n" +
                 "      \"level\": \"info\",\n" +
-                "      \"message\": \"Information.\",\n" +
-                "      \"rawMessage\": \"Information.\",\n" +
+                "      \"text\": \"Information.\",\n" +
+                "      \"rawText\": \"Information.\",\n" +
                 "      \"timestamp\": <timestamp>\n" +
                 "    },\n" +
                 "    {\n" +
                 "      \"something\": \"else\",\n" +
                 "      \"level\": \"error\",\n" +
-                "      \"message\": \"abgeleitete Klasse\",\n" +
-                "      \"rawMessage\": \"derivedclass\",\n" +
+                "      \"text\": \"abgeleitete Klasse\",\n" +
+                "      \"rawText\": \"derivedclass\",\n" +
                 "      \"timestamp\": <timestamp>\n" +
                 "    }\n" +
                 "  ],\n" +

--- a/sling/core/commons/src/test/java/com/composum/sling/core/logging/TestMessageContainer.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/logging/TestMessageContainer.java
@@ -1,0 +1,245 @@
+package com.composum.sling.core.logging;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.reflect.TypeToken;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link MessageContainer} and {@link Message}. */
+public class TestMessageContainer {
+
+    public static final String TIMESTAMP_REGEX = "157[0-9]{10}";
+
+    @Rule
+    public ErrorCollector ec = new ErrorCollector();
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestMessageContainer.class);
+
+    @Test
+    public void jsonizeAndBack() {
+        MessageContainer container = new MessageContainer(LOG);
+        container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17))
+                .add(new Message(null, "Minimal message"))
+                .add(new Message(Message.Level.info, "Message {} with details", 3)
+                        .addDetail(new Message(Message.Level.debug, "Detail {}", 1))
+                        .addDetail(new Message(Message.Level.info, "Detail {}", 2))
+                );
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(container);
+        MessageContainer readback = gson.fromJson(json, MessageContainer.class);
+        ec.checkThat(readback.getMessages().size(), is(3));
+        String json2 = gson.toJson(readback);
+        ec.checkThat(json2.replaceAll("\\.0", ""), is(json)); // 3 becomes 3.0 - difficult to change and we ignore that
+
+        compare(json, "[\n" +
+                "  {\n" +
+                "    \"level\": \"warn\",\n" +
+                "    \"message\": \"Some problem with foo number 17\",\n" +
+                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
+                "    \"arguments\": [\n" +
+                "      \"foo\",\n" +
+                "      17\n" +
+                "    ],\n" +
+                "    \"timestamp\": <timestamp>\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"message\": \"Minimal message\",\n" +
+                "    \"rawMessage\": \"Minimal message\",\n" +
+                "    \"timestamp\": <timestamp>\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"level\": \"info\",\n" +
+                "    \"message\": \"Message 3 with details\",\n" +
+                "    \"rawMessage\": \"Message {} with details\",\n" +
+                "    \"arguments\": [\n" +
+                "      3\n" +
+                "    ],\n" +
+                "    \"details\": [\n" +
+                "      {\n" +
+                "        \"level\": \"debug\",\n" +
+                "        \"message\": \"Detail 1\",\n" +
+                "        \"rawMessage\": \"Detail {}\",\n" +
+                "        \"arguments\": [\n" +
+                "          1\n" +
+                "        ],\n" +
+                "        \"timestamp\": <timestamp>\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"level\": \"info\",\n" +
+                "        \"message\": \"Detail 2\",\n" +
+                "        \"rawMessage\": \"Detail {}\",\n" +
+                "        \"arguments\": [\n" +
+                "          2\n" +
+                "        ],\n" +
+                "        \"timestamp\": <timestamp>\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"timestamp\": <timestamp>\n" +
+                "  }\n" +
+                "]");
+
+        System.out.println(json.replaceAll(TIMESTAMP_REGEX, "<timestamp>"));
+
+        String textrep = container.getMessages().stream()
+                .map(Message::toFormattedMessage)
+                .collect(Collectors.joining("\n"));
+        compare(textrep, "Some problem with foo number 17\n" +
+                "Minimal message\n" +
+                "Message 3 with details\n" +
+                "    Details:\n" +
+                "    debug: Detail 1\n" +
+                "    Detail 2");
+    }
+
+    @Test
+    public void i18n() throws IOException {
+        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        ResourceBundle bundle = new PropertyResourceBundle(new StringReader(
+                "Some\\ problem\\ with\\ {}\\ number\\ {}: Ein Problem mit {} Nummer {}"));
+        Mockito.when(request.getResourceBundle(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(bundle);
+
+        MessageContainer container = new MessageContainer(LOG);
+        container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17));
+        container.i18n(request);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        compare(gson.toJson(container), "[\n" +
+                "  {\n" +
+                "    \"level\": \"warn\",\n" +
+                "    \"message\": \"Ein Problem mit foo Nummer 17\",\n" +
+                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
+                "    \"arguments\": [\n" +
+                "      \"foo\",\n" +
+                "      17\n" +
+                "    ],\n" +
+                "    \"timestamp\": <timestamp>\n" +
+                "  }\n" +
+                "]");
+    }
+
+    @Test
+    public void i18nViaTypeAdapterFactory() throws IOException {
+        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        ResourceBundle bundle = new PropertyResourceBundle(new StringReader(
+                "Some\\ problem\\ with\\ {}\\ number\\ {}: Ein Problem mit {} Nummer {}"));
+        Mockito.when(request.getResourceBundle(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(bundle);
+
+        MessageContainer container = new MessageContainer(LOG);
+        container.add(new Message(Message.Level.warn, "Some problem with {} number {}", "foo", 17));
+        // not: container.i18n(request);
+
+        Gson gson = new GsonBuilder().setPrettyPrinting()
+                .registerTypeAdapterFactory(new MessageTypeAdapterFactory(request))
+                .create();
+
+        compare(gson.toJson(container), "[\n" +
+                "  {\n" +
+                "    \"level\": \"warn\",\n" +
+                "    \"message\": \"Ein Problem mit foo Nummer 17\",\n" +
+                "    \"rawMessage\": \"Some problem with {} number {}\",\n" +
+                "    \"arguments\": [\n" +
+                "      \"foo\",\n" +
+                "      17\n" +
+                "    ],\n" +
+                "    \"timestamp\": <timestamp>\n" +
+                "  }\n" +
+                "]");
+    }
+
+    protected void compare(String json, String expectedJson) {
+        System.out.println(json.replaceAll(TIMESTAMP_REGEX, "<timestamp>"));
+        System.out.println("\n");
+        ec.checkThat(json.replaceAll(TIMESTAMP_REGEX, "<timestamp>"), is(expectedJson));
+    }
+
+    static class WithMessage {
+        MessageContainer messages;
+        String bar = "thebar";
+
+        class Wrapped {
+            String foo = "thefoo";
+        }
+
+        Wrapped asWrapped() {
+            return new Wrapped();
+        }
+    }
+
+    @JsonAdapter(MessageTypeAdapterFactory.class)
+    static class SubclassOfMessage extends Message {
+        String something = "else";
+
+        public SubclassOfMessage(Level level, String message) {
+            super(level, message);
+        }
+    }
+
+    @Test
+    public void derivedClasses() throws IOException {
+        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        ResourceBundle bundle = new PropertyResourceBundle(new StringReader(
+                "derivedclass: abgeleitete Klasse"));
+        Mockito.when(request.getResourceBundle(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(bundle);
+
+        Gson gson = new GsonBuilder().setPrettyPrinting()
+                .registerTypeAdapterFactory(new MessageTypeAdapterFactory(request))
+                .create();
+
+        WithMessage container = new WithMessage();
+        compare(gson.toJson(container), "{\n" +
+                "  \"bar\": \"thebar\"\n" +
+                "}");
+
+        container.messages = new MessageContainer();
+
+        compare(gson.toJson(container), "{\n" +
+                "  \"messages\": [],\n" +
+                "  \"bar\": \"thebar\"\n" +
+                "}");
+
+        container.messages = new MessageContainer();
+        container.messages.add(Message.info("Information."));
+        container.messages.add(new SubclassOfMessage(Message.Level.error, "derivedclass"));
+        ec.checkThat(Message.class.isAssignableFrom(TypeToken.get(SubclassOfMessage.class).getRawType()), is(true));
+
+        compare(gson.toJson(container), "{\n" +
+                "  \"messages\": [\n" +
+                "    {\n" +
+                "      \"level\": \"info\",\n" +
+                "      \"message\": \"Information.\",\n" +
+                "      \"rawMessage\": \"Information.\",\n" +
+                "      \"timestamp\": <timestamp>\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"something\": \"else\",\n" +
+                "      \"level\": \"error\",\n" +
+                "      \"message\": \"abgeleitete Klasse\",\n" +
+                "      \"rawMessage\": \"derivedclass\",\n" +
+                "      \"timestamp\": <timestamp>\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"bar\": \"thebar\"\n" +
+                "}");
+
+        // For an inner class the outer class is ignored by the default writer.
+        compare(gson.toJson(container.asWrapped()), "{\n" +
+                "  \"foo\": \"thefoo\"\n" +
+                "}");
+    }
+
+}

--- a/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.StringReader;
@@ -24,10 +26,13 @@ import java.util.concurrent.ExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 /** Checks JSON serialization of {@link Status}. */
 public class StatusTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatusTest.class);
 
     @Mock
     private SlingHttpServletRequest request;
@@ -111,6 +116,19 @@ public class StatusTest {
 
         Status readback = gson.fromJson(stringWriter.toString(), Status.class);
         assertNotNull(readback);
+    }
+
+    @Test
+    public void checkLoggingExceptions() {
+        String id = "arg";
+        Status status;
+        status = new Status(request, response);
+        Throwable exception = new RuntimeException("Some exception");
+        status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
+        System.out.println(status.getJsonString());
+        // can't easily check the log output - manual checking required. There should be a stacktrace and a log message
+        // StatusTest - For id arg got exception java.lang.RuntimeException: Some exception
+        assertTrue(status.getJsonString().contains("For id arg got exception java.lang.RuntimeException: Some exception"));
     }
 
     private static class TestStatusExtensionObject {

--- a/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
@@ -131,9 +131,9 @@ public class StatusTest {
     public void checkLoggingExceptions() {
         String id = "arg";
         Status status;
-        status = new Status(request, response);
+        status = new Status(request, response, LOG);
         Throwable exception = new RuntimeException("Some exception");
-        status.withLogging(LOG).error("For id {} got exception {}", id, exception.toString(), exception);
+        status.error("For id {} got exception {}", id, exception.toString(), exception);
         System.out.println(status.getJsonString());
         // can't easily check the log output - manual checking required. There should be a stacktrace and a log message
         // StatusTest - For id arg got exception java.lang.RuntimeException: Some exception
@@ -148,7 +148,7 @@ public class StatusTest {
     private static class TestStatusExtension extends Status {
 
         public TestStatusExtension(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response) {
-            super(request, response);
+            super(request, response, LOG);
         }
 
         TestStatusExtensionObject containedObject;

--- a/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
@@ -1,7 +1,7 @@
 package com.composum.sling.core.servlet;
 
 import com.composum.sling.core.ResourceHandle;
-import com.composum.sling.core.logging.TestMessageContainer;
+import com.composum.sling.core.logging.MessageContainerTest;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonWriter;
@@ -10,7 +10,6 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -82,7 +81,7 @@ public class StatusTest {
                         "\"rawText\":\"hello to {} from {}\",\"arguments\":[\"franz\",17],\"timestamp\":<timestamp>}]," +
                         "\"data\":{\"dat1\":{\"dk1\":15,\"dk2\":18}}," +
                         "\"list\":{\"list1\":[{\"mlkey\":42},{\"mlkey1\":23,\"mlkey2\":54}]}}",
-                stringWriter.toString().replaceAll(TestMessageContainer.TIMESTAMP_REGEX, "<timestamp>"));
+                stringWriter.toString().replaceAll(MessageContainerTest.TIMESTAMP_REGEX, "<timestamp>"));
 
         Status readback = gson.fromJson(stringWriter.toString(), Status.class);
         assertEquals(213, readback.getStatus());
@@ -176,7 +175,7 @@ public class StatusTest {
         ResourceBundle bundle = new PropertyResourceBundle(new StringReader(
                 "with\\ hint\\ {}: mit Hinweis {}\n" +
                         "thehint: der Hinweis\n" +
-                        "thetile: der Titel"));
+                        "thetitle: der Titel"));
         when(request.getResourceBundle(any(), any())).thenReturn(bundle);
         when(request.getReader()).thenReturn(new BufferedReader(new StringReader(json)));
 
@@ -191,11 +190,11 @@ public class StatusTest {
         System.out.println(stringWriter.toString());
 
         // FIXME(hps,16.01.20) "der Titel"
-        assertEquals("{\"status\":404,\"success\":false,\"warning\":true,\"title\":\"thetitle\"," +
+        assertEquals("{\"status\":404,\"success\":false,\"warning\":true,\"title\":\"der Titel\"," +
                         "\"messages\":[{\"level\":\"warn\",\"context\":\"thecontext\",\"label\":\"thelabel\"," +
                         "\"text\":\"mit Hinweis thehint\"," +
                         "\"rawText\":\"with hint {}\",\"arguments\":[\"thehint\"],\"timestamp\":<timestamp>}]}",
-                stringWriter.toString().replaceAll(TestMessageContainer.TIMESTAMP_REGEX, "<timestamp>"));
+                stringWriter.toString().replaceAll(MessageContainerTest.TIMESTAMP_REGEX, "<timestamp>"));
     }
 
 }

--- a/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PropertyResourceBundle;
+import java.util.concurrent.ExecutorService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -96,6 +97,20 @@ public class StatusTest {
         assertNotNull(readback.containedObject);
         assertEquals("hallo", readback.containedObject.attr1);
         assertEquals(Integer.valueOf(27), readback.containedObject.attr2);
+    }
+
+    @Test
+    public void testEmptyStatus() throws Exception {
+        Gson gson = new GsonBuilder().create();
+        Status status = new Status(request, response);
+        Writer stringWriter = new StringWriter();
+        JsonWriter jsonWriter = new JsonWriter(stringWriter);
+        status.toJson(jsonWriter);
+
+        assertEquals("{\"status\":200,\"success\":true,\"warning\":false}", stringWriter.toString());
+
+        Status readback = gson.fromJson(stringWriter.toString(), Status.class);
+        assertNotNull(readback);
     }
 
     private static class TestStatusExtensionObject {

--- a/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/servlet/StatusTest.java
@@ -57,7 +57,7 @@ public class StatusTest {
     public void testSerialization() throws Exception {
         Gson gson = new GsonBuilder().create();
 
-        Status status = new Status(request, response);
+        Status status = new Status(request, response, LOG);
         status.setStatus(213);
         status.setTitle("thetitle");
         status.warn("hello to {} from {}", "franz", 17);
@@ -189,7 +189,6 @@ public class StatusTest {
 
         System.out.println(stringWriter.toString());
 
-        // FIXME(hps,16.01.20) "der Titel"
         assertEquals("{\"status\":404,\"success\":false,\"warning\":true,\"title\":\"der Titel\"," +
                         "\"messages\":[{\"level\":\"warn\",\"context\":\"thecontext\",\"label\":\"thelabel\"," +
                         "\"text\":\"mit Hinweis thehint\"," +

--- a/sling/core/commons/src/test/java/com/composum/sling/core/util/SlingResourceUtilTest.java
+++ b/sling/core/commons/src/test/java/com/composum/sling/core/util/SlingResourceUtilTest.java
@@ -1,6 +1,7 @@
 package com.composum.sling.core.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
@@ -9,6 +10,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.apache.commons.lang3.StringUtils.contains;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -42,6 +46,10 @@ public class SlingResourceUtilTest extends SlingResourceUtil {
         ec.checkThat(relativePath(parent + "/", child), is(relpath));
         ec.checkThat(relativePath(parent + "/", child + "/"), is(relpath));
         ec.checkThat(relativePath(parent, child + "/"), is(relpath));
+        ec.checkThat(startsWith(relpath, "/"), is(false));
+        if (SlingResourceUtil.isSameOrDescendant(parent, child) && !contains(parent, "..") && !contains(child, "..")) {
+            ec.checkThat("for " + parent + " , " + child, appendPaths(parent, relpath), is(child));
+        }
         return relpath;
     }
 
@@ -66,9 +74,18 @@ public class SlingResourceUtilTest extends SlingResourceUtil {
     }
 
     protected void checkAppendPaths(String path, String childpath, String result) {
-        ec.checkThat(path + " with " + childpath, appendPaths(path, childpath), equalTo(result));
-        ec.checkThat(path + " with " + childpath, StringUtils.startsWith(path, "/"),
-                equalTo(StringUtils.startsWith(result, "/")));
+        String appended = appendPaths(path, childpath);
+        ec.checkThat(path + " with " + childpath, appended, equalTo(result));
+        ec.checkThat(path + " with " + childpath, startsWith(path, "/"),
+                equalTo(startsWith(result, "/")));
+        if (isNotBlank(path) && isNotBlank(childpath) && isNotBlank(appended)) {
+            if (startsWith(childpath, "/")) {
+                ec.checkThat("for " + path + " , " + childpath, relativePath(path, appended),
+                        is(StringUtils.removeStart(childpath, "/")));
+            } else {
+                ec.checkThat("for " + path + " , " + childpath, relativePath(path, appended), is(childpath));
+            }
+        }
     }
 
     @Test

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -389,6 +389,11 @@ public class SourceModel extends ConsoleSlingBean {
      */
     public void writeZip(@Nonnull ZipOutputStream zipStream, @Nonnull String root, boolean writeDeep)
             throws IOException, RepositoryException {
+        if (ResourceUtil.isFile(resource)) {
+            if (writeDeep) { writeFile(zipStream, root, resource); }
+            // not writeDeep: a .content.xml is not present for a file, so we can't do anything.
+            return;
+        }
 
         ZipEntry entry;
         String path = resource.getPath();
@@ -424,7 +429,10 @@ public class SourceModel extends ConsoleSlingBean {
      */
     protected void writeFile(ZipOutputStream zipStream, String root, ResourceHandle file)
             throws IOException, RepositoryException {
-        if (file.getName().equals(JcrConstants.JCR_CONTENT)) { throw new IllegalArgumentException(); } // safety check
+        if (file.getName().equals(JcrConstants.JCR_CONTENT)) {
+            // file format doesn't allow this - we need to write the file with the parent's name
+            file = file.getParent();
+        }
 
         FileTime lastModified = getLastModified(file);
         ZipEntry entry;

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -389,6 +389,9 @@ public class SourceModel extends ConsoleSlingBean {
      */
     public void writeZip(@Nonnull ZipOutputStream zipStream, @Nonnull String root, boolean writeDeep)
             throws IOException, RepositoryException {
+        if (resource == null || ResourceUtil.isNonExistingResource(resource)) {
+            return;
+        }
         if (ResourceUtil.isFile(resource)) {
             if (writeDeep) { writeFile(zipStream, root, resource); }
             // not writeDeep: a .content.xml is not present for a file, so we can't do anything.

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceModel.java
@@ -13,6 +13,7 @@ import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.jcr.Binary;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
@@ -181,8 +182,9 @@ public class SourceModel extends ConsoleSlingBean {
     private transient List<Resource> subnodeList;
 
     public SourceModel(NodesConfiguration config, BeanContext context, Resource resource) {
-        if ("/".equals(ResourceUtil.normalize(resource.getPath())))
+        if ("/".equals(ResourceUtil.normalize(resource.getPath()))) {
             throw new IllegalArgumentException("Cannot export the whole JCR - " + resource.getPath());
+        }
         this.config = config;
         initialize(context, resource);
     }
@@ -292,20 +294,21 @@ public class SourceModel extends ConsoleSlingBean {
 
     // Package output
 
+    /** Writes a complete package about the node - arguments specify the package metadata. */
     public void writePackage(OutputStream output, String group, String name, String version)
             throws IOException, RepositoryException {
 
         String root = "jcr_root";
         ZipOutputStream zipStream = new ZipOutputStream(output);
-        writeProperties(zipStream, group, name, version);
-        writeFilter(zipStream);
+        writePackageProperties(zipStream, group, name, version);
+        writeFilterXml(zipStream);
         writeParents(zipStream, root, resource.getParent());
         writeZip(zipStream, root, true);
         zipStream.flush();
         zipStream.close();
     }
 
-    public void writeProperties(ZipOutputStream zipStream, String group, String name, String version)
+    protected void writePackageProperties(ZipOutputStream zipStream, String group, String name, String version)
             throws IOException {
 
         ZipEntry entry;
@@ -313,29 +316,29 @@ public class SourceModel extends ConsoleSlingBean {
         zipStream.putNextEntry(entry);
 
         Writer writer = new OutputStreamWriter(zipStream, "UTF-8");
-            writer.append("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n")
-                    .append("<!DOCTYPE properties SYSTEM \"http://java.sun.com/dtd/properties.dtd\">\n")
-                    .append("<properties>\n")
-                    .append("<comment>FileVault Package Properties</comment>\n")
-                    .append("<entry key=\"name\">")
-                    .append(name)
-                    .append("</entry>\n")
-                    .append("<entry key=\"buildCount\">1</entry>\n")
-                    .append("<entry key=\"version\">")
-                    .append(version)
-                    .append("</entry>\n")
-                    .append("<entry key=\"packageFormatVersion\">2</entry>\n")
-                    .append("<entry key=\"group\">")
-                    .append(group)
-                    .append("</entry>\n")
-                    .append("<entry key=\"description\">created from source download</entry>\n")
-                    .append("</properties>");
+        writer.append("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n")
+                .append("<!DOCTYPE properties SYSTEM \"http://java.sun.com/dtd/properties.dtd\">\n")
+                .append("<properties>\n")
+                .append("<comment>FileVault Package Properties</comment>\n")
+                .append("<entry key=\"name\">")
+                .append(name)
+                .append("</entry>\n")
+                .append("<entry key=\"buildCount\">1</entry>\n")
+                .append("<entry key=\"version\">")
+                .append(version)
+                .append("</entry>\n")
+                .append("<entry key=\"packageFormatVersion\">2</entry>\n")
+                .append("<entry key=\"group\">")
+                .append(group)
+                .append("</entry>\n")
+                .append("<entry key=\"description\">created from source download</entry>\n")
+                .append("</properties>");
 
         writer.flush();
         zipStream.closeEntry();
     }
 
-    public void writeFilter(ZipOutputStream zipStream) throws IOException {
+    protected void writeFilterXml(ZipOutputStream zipStream) throws IOException {
 
         String path = resource.getPath();
 
@@ -344,18 +347,19 @@ public class SourceModel extends ConsoleSlingBean {
         zipStream.putNextEntry(entry);
 
         Writer writer = new OutputStreamWriter(zipStream, "UTF-8");
-            writer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-                    .append("<workspaceFilter version=\"1.0\">\n")
-                    .append("    <filter root=\"")
-                    .append(path)
-                    .append("\"/>\n")
-                    .append("</workspaceFilter>\n");
+        writer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+                .append("<workspaceFilter version=\"1.0\">\n")
+                .append("    <filter root=\"")
+                .append(path)
+                .append("\"/>\n")
+                .append("</workspaceFilter>\n");
 
         writer.flush();
         zipStream.closeEntry();
     }
 
-    public void writeParents(ZipOutputStream zipStream, String root, Resource parent)
+    /** Writes all the .content.xml of the parents of root into the zip. */
+    protected void writeParents(@Nonnull ZipOutputStream zipStream, @Nonnull String root, @Nonnull Resource parent)
             throws IOException, RepositoryException {
         if (parent != null && !"/".equals(parent.getPath())) {
             writeParents(zipStream, root, parent.getParent());
@@ -366,7 +370,8 @@ public class SourceModel extends ConsoleSlingBean {
 
     // ZIP output
 
-    public void writeArchive(OutputStream output)
+    /** Writes a "naked" Zip about the node: no package metadata, no parent nodes. */
+    public void writeArchive(@Nonnull OutputStream output)
             throws IOException, RepositoryException {
 
         ZipOutputStream zipStream = new ZipOutputStream(output);
@@ -375,7 +380,14 @@ public class SourceModel extends ConsoleSlingBean {
         zipStream.close();
     }
 
-    public void writeZip(ZipOutputStream zipStream, String root, boolean writeDeep)
+    /**
+     * Writes a "naked" Zip about the node: no package metadata, no parent nodes.
+     *
+     * @param zipStream the stream to write to, not closed.
+     * @param writeDeep if true, we also write subnodes recursively. If not, only a jcr:content node is written, if
+     *                  present.
+     */
+    public void writeZip(@Nonnull ZipOutputStream zipStream, @Nonnull String root, boolean writeDeep)
             throws IOException, RepositoryException {
 
         ZipEntry entry;
@@ -388,7 +400,7 @@ public class SourceModel extends ConsoleSlingBean {
         }
         zipStream.putNextEntry(entry);
         Writer writer = new OutputStreamWriter(zipStream, "UTF-8");
-            writeFile(writer, true, false);
+        writeContentXmlFile(writer, true, false);
         writer.flush();
         zipStream.closeEntry();
 
@@ -406,8 +418,14 @@ public class SourceModel extends ConsoleSlingBean {
         }
     }
 
-    public void writeFile(ZipOutputStream zipStream, String root, ResourceHandle file)
+    /**
+     * Writes the current node as a file node (not the jcr:content but the parent) incl. it's binary data and possibly
+     * additional data about nonstandard properties.
+     */
+    protected void writeFile(ZipOutputStream zipStream, String root, ResourceHandle file)
             throws IOException, RepositoryException {
+        if (file.getName().equals(JcrConstants.JCR_CONTENT)) { throw new IllegalArgumentException(); } // safety check
+
         FileTime lastModified = getLastModified(file);
         ZipEntry entry;
         String path = file.getPath();
@@ -440,13 +458,13 @@ public class SourceModel extends ConsoleSlingBean {
             zipStream.putNextEntry(entry);
             Writer writer = new OutputStreamWriter(zipStream, UTF_8);
             SourceModel fileModel = new SourceModel(config, context, file);
-            fileModel.writeFile(writer, false, false);
+            fileModel.writeContentXmlFile(writer, false, false);
             writer.flush();
             zipStream.closeEntry();
         }
     }
 
-    public String getZipName(String root, String path) {
+    protected String getZipName(@Nonnull String root, @Nonnull String path) {
         String name = path;
         if (name.startsWith(root)) {
             name = name.substring(root.length() + 1);
@@ -458,7 +476,14 @@ public class SourceModel extends ConsoleSlingBean {
 
     // XML output
 
-    public void writeFile(Writer writer, boolean contentOnly, boolean noSubnodeNames)
+    /**
+     * Writes the data for the .content.xml file for the node, including an jcr:content node if present.
+     *
+     * @param contentOnly    if true, subnodes other than jcr:content are also included
+     * @param noSubnodeNames if false and the node has a jcr:content, we also write nodes for the names of the
+     *                       siblings of the jcr:content node to indicate the order of the subnodes.
+     */
+    protected void writeContentXmlFile(Writer writer, boolean contentOnly, boolean noSubnodeNames)
             throws IOException, RepositoryException {
         List<String> namespaces = new ArrayList<>();
         namespaces.add("jcr");
@@ -466,18 +491,7 @@ public class SourceModel extends ConsoleSlingBean {
         Collections.sort(namespaces);
         writer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         writer.append("<jcr:root");
-        for (int i = 0; i < namespaces.size(); ) {
-            String ns = namespaces.get(i);
-            String url = getSession().getNamespaceURI(ns);
-            if (StringUtils.isNotBlank(url)) {
-                writer.append(" xmlns:").append(ns).append("=\"").append(url).append("\"");
-                if (++i < namespaces.size()) {
-                    writer.append("\n         ");
-                }
-            } else {
-                i++;
-            }
-        }
+        writeNamespaceAttributes(writer, namespaces);
         writeProperty(writer, "          ", "jcr:primaryType", getPrimaryType());
         writeProperties(writer, "          ");
         writer.append(">\n");
@@ -495,40 +509,41 @@ public class SourceModel extends ConsoleSlingBean {
             }
         } else {
             if (!contentOnly) {
-                writeSubnodes(writer, "    ");
+                writeSubnodesAsXml(writer, "    ");
             }
         }
         writer.append("</jcr:root>\n");
     }
 
-    public void writeXml(Writer writer, String indent) throws IOException {
+    /** Writes the node including subnodes as XML, using the base indentation. */
+    protected void writeXml(Writer writer, String indent) throws IOException {
         String name = escapeXmlName(getName());
         writer.append(indent).append("<").append(name).append('\n');
         writer.append(indent).append("        ").append("jcr:primaryType=\"").append(getPrimaryType()).append("\"");
         writeProperties(writer, indent + "        ");
         if (getHasSubnodes()) {
             writer.append(">\n");
-            writeSubnodes(writer, indent + "    ");
+            writeSubnodesAsXml(writer, indent + "    ");
             writer.append(indent).append("</").append(name).append(">\n");
         } else {
             writer.append("/>\n");
         }
     }
 
-    public void writeSubnodes(Writer writer, String indent) throws IOException {
+    protected void writeSubnodesAsXml(Writer writer, String indent) throws IOException {
         for (Resource subnode : getSubnodeList()) {
             SourceModel subnodeModel = new SourceModel(config, context, subnode);
             subnodeModel.writeXml(writer, indent);
         }
     }
 
-    public void writeProperties(Writer writer, String indent) throws IOException {
+    protected void writeProperties(Writer writer, String indent) throws IOException {
         for (Property property : getPropertyList()) {
             writeProperty(writer, indent, property.getName(), property.getString(indent));
         }
     }
 
-    public void writeProperty(Writer writer, String indent, String name, String value)
+    protected void writeProperty(Writer writer, String indent, String name, String value)
             throws IOException {
         writer.append("\n");
         writer.append(indent);
@@ -536,6 +551,21 @@ public class SourceModel extends ConsoleSlingBean {
         writer.append("=\"");
         writer.append(escapeXmlAttribute(value));
         writer.append("\"");
+    }
+
+    protected void writeNamespaceAttributes(Writer writer, List<String> namespaces) throws RepositoryException, IOException {
+        for (int i = 0; i < namespaces.size(); ) {
+            String ns = namespaces.get(i);
+            String url = getSession().getNamespaceURI(ns);
+            if (StringUtils.isNotBlank(url)) {
+                writer.append(" xmlns:").append(ns).append("=\"").append(url).append("\"");
+                if (++i < namespaces.size()) {
+                    writer.append("\n         ");
+                }
+            } else {
+                i++;
+            }
+        }
     }
 
     public String escapeXmlName(String name) {

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceServlet.java
@@ -78,7 +78,7 @@ public class SourceServlet extends SlingSafeMethodsServlet {
                         //response.setContentType("application/octet-stream");
                         response.setHeader("Content-Disposition", "inline; filename=.content.xml");
 
-                        sourceModel.writeFile(response.getWriter(),
+                        sourceModel.writeContentXmlFile(response.getWriter(),
                                 RequestUtil.checkSelector(request, "content"),
                                 RequestUtil.checkSelector(request, "node"));
                         break;


### PR DESCRIPTION
- Refactors Status: all messages are logged when added, extracted MessageContainer and Message for use independent of Status; Status can now be serialized and deserialized from JSON
- Refactors and fixes bug in SourceModel if you want to package a single jcr:content
- some additions to SlingResourceUtil

There is a deprecated method Status.withLogging left which sets Status' logger and returns the Status itself. This can be removed when this is merged into core and its usages in platform etc. are removed. I don't currently want to do that since that would need simultaneous merging of this PR and PRs in the other projects.