### PR TITLE
Adding support for Groovy 3

### DIFF
--- a/sling/core/commons/pom.xml
+++ b/sling/core/commons/pom.xml
@@ -67,7 +67,8 @@
                         <Import-Package>
                             org.apache.sling.event.jobs.consumer.*;version="[1.1,3)",
                             org.apache.sling.event.jobs.*;version="[1.3,3)",
-                            groovy.lang.*;version="[2.2.2,3)",
+                            groovy.*;version="[2.2,4]",
+                            org.codehaus.groovy.*;version="[2.2,4]",
                             javax.annotation.*;version="[0,4)",
                             *
                         </Import-Package>


### PR DESCRIPTION
Currently, Composum is not compatible with Groovy 3. Updating the version range to support any Groovy version less than 4. 

Note this has been tested with Groovy 3.0.1 and 2.4.7 on Sling Starter 12-SNAPSHOT.