### PR TITLE
Set sling.auth.requirements for top-level servlets

### DIFF
--- a/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
@@ -4,6 +4,8 @@ import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -17,6 +19,9 @@ import static com.composum.sling.nodes.browser.BrowserServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class BrowserServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/browser";

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
@@ -3,6 +3,8 @@ package com.composum.sling.core.pckgmgr.view;
 import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
@@ -17,6 +19,9 @@ import static com.composum.sling.core.pckgmgr.view.PackagesServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class PackagesServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/packages";

--- a/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
+++ b/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
@@ -4,6 +4,9 @@ import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -17,6 +20,9 @@ import static com.composum.sling.core.usermanagement.UserManagerServlet.SERVLET_
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class UserManagerServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/users";


### PR DESCRIPTION
This instructs the Sling authenticator to prompt users for authentication if
needed, and is a better end-user experience compared to getting a 403 response.

Closes #180