### PR TITLE
Set sling.auth.requirements for most console servlets #204

### DIFF
--- a/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/DebugClientlibGraphServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/clientlibs/servlet/DebugClientlibGraphServlet.java
@@ -1,6 +1,8 @@
 package com.composum.sling.clientlibs.servlet;
 
 import com.composum.sling.clientlibs.handle.*;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -23,6 +25,8 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.composum.sling.clientlibs.servlet.DebugClientlibGraphServlet.SERVLET_PATH;
+
 /**
  * Tries to print a graph of all client libraries. Unfortunately it is somewhat too complex to be useful.
  * <p>
@@ -37,12 +41,17 @@ import java.util.List;
  */
 @SlingServlet(
         methods = HttpConstants.METHOD_GET,
-        paths = "/bin/cpm/nodes/debug/clientlibgraph"
+        paths = SERVLET_PATH
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 @Deprecated
 public class DebugClientlibGraphServlet extends SlingSafeMethodsServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(DebugClientlibGraphServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/debug/clientlibgraph";
 
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/JobControlServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/JobControlServlet.java
@@ -10,6 +10,8 @@ import com.composum.sling.core.util.ResponseUtil;
 import com.composum.sling.core.util.XSS;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -29,33 +31,26 @@ import javax.jcr.Session;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.composum.sling.core.servlet.JobControlServlet.SERVLET_PATH;
+
 @SlingServlet(
-        paths = "/bin/cpm/core/jobcontrol",
+        paths = SERVLET_PATH,
         methods = {"GET", "PUT", "POST", "DELETE"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class JobControlServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobControlServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/core/jobcontrol";
 
     public enum Extension {txt, json}
 
@@ -392,7 +387,7 @@ public class JobControlServlet extends AbstractServiceServlet {
 
     /**
      * Creates a new job.
-     *
+     * <p>
      * used parameters:
      * <ul>
      * <li>outfileprefix</li>

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/SystemServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/SystemServlet.java
@@ -17,6 +17,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -39,16 +41,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.composum.sling.core.servlet.SystemServlet.SERVLET_PATH;
+
 /**
  * The service servlet to retrieve all general system settings.
  */
 @SlingServlet(
-        paths = "/bin/cpm/core/system",
+        paths = SERVLET_PATH,
         methods = {"GET", "PUT"}
 )
+@Properties(value={
+        @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class SystemServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(SystemServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/core/system";
 
     public static final String NODE_TYPES_PATH = "/jcr:system/jcr:nodeTypes";
 

--- a/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
+++ b/sling/core/commons/src/main/java/com/composum/sling/core/servlet/TranslationServlet.java
@@ -4,6 +4,8 @@ import com.composum.sling.core.CoreConfiguration;
 import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.logging.Message;
 import com.composum.sling.core.service.TranslationService;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -18,17 +20,21 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-import static javax.servlet.http.HttpServletResponse.SC_ACCEPTED;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static com.composum.sling.core.servlet.TranslationServlet.SERVLET_PATH;
+import static javax.servlet.http.HttpServletResponse.*;
 
 @SlingServlet(
-        paths = "/bin/cpm/core/translate",
+        paths = SERVLET_PATH,
         methods = {"PUT"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class TranslationServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(TranslationServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/core/translate";
 
     public static final String STATUS = "status";
     public static final String SUCCESS = "success";
@@ -106,7 +112,9 @@ public class TranslationServlet extends AbstractServiceServlet {
             status.sendJson(SC_OK); // the normal i18n of Status and its Messages takes care of the translation.
         }
 
-        /** Parses the request format. */
+        /**
+         * Parses the request format.
+         */
         protected void readFrom(BufferedReader reader, Status status) {
             Map<String, Object> data = status.getGson().fromJson(reader, Map.class);
             Object value;
@@ -148,7 +156,9 @@ public class TranslationServlet extends AbstractServiceServlet {
 
         }
 
-        /** Reads a message from the input format. */
+        /**
+         * Reads a message from the input format.
+         */
         protected Message parseMessage(Map<String, Object> data) {
             Object value;
             Object hint = data.get(HINT);

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
@@ -3,9 +3,9 @@ package com.composum.sling.nodes.browser;
 import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -19,8 +19,8 @@ import static com.composum.sling.nodes.browser.BrowserServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
-@Properties(value={
-    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
 })
 public class BrowserServlet extends AbstractConsoleServlet {
 

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/browser/BrowserServlet.java
@@ -4,6 +4,8 @@ import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -17,6 +19,9 @@ import static com.composum.sling.nodes.browser.BrowserServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class BrowserServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/browser";

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/components/codeeditor/CodeEditorServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/components/codeeditor/CodeEditorServlet.java
@@ -3,6 +3,8 @@ package com.composum.sling.nodes.components.codeeditor;
 import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
@@ -18,6 +20,9 @@ import static com.composum.sling.nodes.components.codeeditor.CodeEditorServlet.S
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+        @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class CodeEditorServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/cpm/edit/code";

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/NodeServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/NodeServlet.java
@@ -11,19 +11,14 @@ import com.composum.sling.core.servlet.AbstractServiceServlet;
 import com.composum.sling.core.servlet.NodeTreeServlet;
 import com.composum.sling.core.servlet.ServletOperation;
 import com.composum.sling.core.servlet.ServletOperationSet;
-import com.composum.sling.core.util.I18N;
-import com.composum.sling.core.util.JsonUtil;
-import com.composum.sling.core.util.MimeTypeUtil;
-import com.composum.sling.core.util.RequestUtil;
-import com.composum.sling.core.util.ResourceUtil;
-import com.composum.sling.core.util.ResponseUtil;
-import com.composum.sling.core.util.XSS;
+import com.composum.sling.core.util.*;
 import com.composum.sling.cpnl.CpnlElFunctions;
 import com.composum.sling.nodes.NodesConfiguration;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.ReferencePolicy;
@@ -44,16 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.jcr.Binary;
-import javax.jcr.ItemExistsException;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.UnsupportedRepositoryOperationException;
-import javax.jcr.Workspace;
+import javax.jcr.*;
 import javax.jcr.lock.Lock;
 import javax.jcr.lock.LockManager;
 import javax.jcr.nodetype.NodeType;
@@ -63,39 +49,30 @@ import javax.jcr.query.QueryResult;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.composum.sling.core.mapping.MappingRules.CHARSET;
+import static com.composum.sling.nodes.servlet.NodeServlet.SERVLET_PATH;
 
 /**
  * The JCR nodes service servlet to walk though and modify the entire hierarchy.
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/node",
+        paths = SERVLET_PATH,
         methods = {"GET", "POST", "PUT", "DELETE"}
 )
+@Properties(value = {
+        @org.apache.felix.scr.annotations.Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class NodeServlet extends NodeTreeServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/node";
 
     public static final String SCRIPT_STATUS_HEADER = "Script-Status";
 

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/NodeTypesServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/NodeTypesServlet.java
@@ -2,6 +2,8 @@ package com.composum.sling.nodes.servlet;
 
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.commons.cnd.CompactNodeTypeDefWriter;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -19,15 +21,20 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static com.composum.sling.nodes.servlet.NodeTypesServlet.SERVLET_PATH;
+
 /**
  * A servlet that exports the nodetypes in the format used in nodetypes.cnd.
  * E.g. <code>http://localhost:9090/bin/cpm/nodes/debug/nodetypes?nameregex=cpp%3A.%2A</code>
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/debug/nodetypes",
+        paths = SERVLET_PATH,
         methods = {"GET"},
         description = "Composum Show Nodetype Servlet"
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 //@Component(service = Servlet.class,
 //        property = {
 //                Constants.SERVICE_DESCRIPTION + "=",
@@ -35,6 +42,8 @@ import java.util.regex.Pattern;
 //                "sling.servlet.methods=" + HttpConstants.METHOD_GET
 //        })
 public class NodeTypesServlet extends SlingSafeMethodsServlet {
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/debug/nodetypes";
 
     /**
      * Request parameter with a regular expression to select the nodetypes to write.

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/PropertyServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/PropertyServlet.java
@@ -7,16 +7,12 @@ import com.composum.sling.core.servlet.AbstractServiceServlet;
 import com.composum.sling.core.servlet.ServletOperation;
 import com.composum.sling.core.servlet.ServletOperationSet;
 import com.composum.sling.core.servlet.Status;
-import com.composum.sling.core.util.JsonUtil;
-import com.composum.sling.core.util.MimeTypeUtil;
-import com.composum.sling.core.util.PropertyUtil;
-import com.composum.sling.core.util.RequestUtil;
-import com.composum.sling.core.util.ResponseUtil;
-import com.composum.sling.core.util.XSS;
+import com.composum.sling.core.util.*;
 import com.composum.sling.nodes.NodesConfiguration;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.JcrConstants;
@@ -33,14 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.jcr.Binary;
-import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Value;
+import javax.jcr.*;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedInputStream;
@@ -51,19 +40,24 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import static com.composum.sling.nodes.servlet.PropertyServlet.SERVLET_PATH;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 /**
  * The service servlet handling one single JCR property for one resource.
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/property",
+        paths = SERVLET_PATH,
         methods = {"GET", "POST", "PUT"}
 )
+@Properties(value = {
+        @org.apache.felix.scr.annotations.Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class PropertyServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(PropertyServlet.class);
 
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/property";
     public static final StringFilter DEFAULT_PROPS_FILTER = new StringFilter.BlackList();
     public static final StringFilter BINARY_PROPS_FILTER = new StringFilter.BlackList();
 

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SecurityServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SecurityServlet.java
@@ -11,6 +11,8 @@ import com.composum.sling.core.util.XSS;
 import com.composum.sling.cpnl.CpnlElFunctions;
 import com.composum.sling.nodes.NodesConfiguration;
 import com.google.gson.stream.JsonWriter;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -31,39 +33,32 @@ import org.slf4j.LoggerFactory;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
-import javax.jcr.security.AccessControlEntry;
-import javax.jcr.security.AccessControlList;
-import javax.jcr.security.AccessControlManager;
-import javax.jcr.security.AccessControlPolicy;
-import javax.jcr.security.AccessControlPolicyIterator;
-import javax.jcr.security.NamedAccessControlPolicy;
-import javax.jcr.security.Privilege;
+import javax.jcr.security.*;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.composum.sling.core.mapping.MappingRules.CHARSET;
+import static com.composum.sling.nodes.servlet.SecurityServlet.SERVLET_PATH;
 
 /**
  * The service servlet to retrieve all general system settings.
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/security",
+        paths = SERVLET_PATH,
         methods = {"GET", "POST", "PUT", "DELETE"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class SecurityServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityServlet.class);
 
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/security";
     public static final String PARAM_SCOPE = "scope";
 
     public enum PolicyScope {local, effective}

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceServlet.java
@@ -6,6 +6,8 @@ import com.composum.sling.core.util.XSS;
 import com.composum.sling.nodes.NodesConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -21,12 +23,19 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.composum.sling.nodes.servlet.SourceServlet.SERVLET_PATH;
+
 @SlingServlet(
         methods = {"GET"},
-        paths = "/bin/cpm/nodes/source",
+        paths = SERVLET_PATH,
         extensions = {"xml", "zip", "pkg"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class SourceServlet extends SlingSafeMethodsServlet {
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/source";
 
     @Reference
     protected NodesConfiguration nodesConfig;

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceUpdateServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/SourceUpdateServlet.java
@@ -5,6 +5,8 @@ import com.composum.sling.core.util.XSS;
 import com.composum.sling.nodes.NodesConfiguration;
 import com.composum.sling.nodes.update.SourceUpdateService;
 import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -25,7 +27,6 @@ import java.io.IOException;
 
 import static org.apache.sling.api.servlets.HttpConstants.METHOD_POST;
 
-
 /**
  * Modifies JCR content according to a given XML or ZIP of XMLs while preserving / updating metadata like versioning
  * information and metadata. This is a kind of opposite operation as the {@link SourceServlet}: the nodes like
@@ -35,11 +36,16 @@ import static org.apache.sling.api.servlets.HttpConstants.METHOD_POST;
  * TODO: perhaps keep special nodes like cpp:MetaData (used for statistics) unchanged
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/sourceupload",
+        paths = SourceUpdateServlet.SERVLET_PATH,
         methods = METHOD_POST,
         extensions = {"zip"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SourceUpdateServlet.SERVLET_PATH})
+})
 public class SourceUpdateServlet extends SlingAllMethodsServlet {
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/sourceupload";
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceUpdateServlet.class);
 
@@ -94,3 +100,4 @@ public class SourceUpdateServlet extends SlingAllMethodsServlet {
 
     }
 }
+

--- a/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/VersionServlet.java
+++ b/sling/core/console/src/main/java/com/composum/sling/nodes/servlet/VersionServlet.java
@@ -1,14 +1,16 @@
 package com.composum.sling.nodes.servlet;
 
-import com.composum.sling.nodes.NodesConfiguration;
 import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.mapping.MappingRules;
 import com.composum.sling.core.servlet.AbstractServiceServlet;
 import com.composum.sling.core.servlet.ServletOperation;
 import com.composum.sling.core.servlet.ServletOperationSet;
 import com.composum.sling.core.util.ResponseUtil;
+import com.composum.sling.nodes.NodesConfiguration;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonWriter;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -37,15 +39,22 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 
+import static com.composum.sling.nodes.servlet.VersionServlet.SERVLET_PATH;
+
 /**
  * @author Mirko Zeibig
  * @since 28.09.2015
  */
 @SlingServlet(
-        paths = "/bin/cpm/nodes/version",
+        paths = SERVLET_PATH,
         methods = {"GET", "PUT", "POST"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class VersionServlet extends AbstractServiceServlet {
+
+    public static final String SERVLET_PATH = "/bin/cpm/nodes/version";
 
     private static final Logger LOG = LoggerFactory.getLogger(VersionServlet.class);
 
@@ -58,7 +67,8 @@ public class VersionServlet extends AbstractServiceServlet {
     @Reference
     private NodesConfiguration coreConfig;
 
-    @Override protected boolean isEnabled() {
+    @Override
+    protected boolean isEnabled() {
         return coreConfig.isEnabled(this);
     }
 
@@ -86,7 +96,8 @@ public class VersionServlet extends AbstractServiceServlet {
         operations.setOperation(ServletOperationSet.Method.POST, Extension.json, Operation.configuration, new CreateConfiguration());
     }
 
-    @Override protected ServletOperationSet getOperations() {
+    @Override
+    protected ServletOperationSet getOperations() {
         return operations;
     }
 
@@ -94,11 +105,13 @@ public class VersionServlet extends AbstractServiceServlet {
         String versionName;
         String date;
         List<String> labels = new ArrayList<>();
+
         VersionEntry(String versionName, String date) {
             this.versionName = versionName;
             this.date = date;
         }
     }
+
     static class Param {
         String version;
         String label;
@@ -119,8 +132,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class RestoreVersion implements ServletOperation {
 
-        @Override public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
-                ResourceHandle resource) throws RepositoryException, IOException, ServletException {
+        @Override
+        public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
+                         ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -141,8 +155,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class DeleteVersion implements ServletOperation {
 
-        @Override public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
-                ResourceHandle resource) throws RepositoryException, IOException, ServletException {
+        @Override
+        public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
+                         ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -164,8 +179,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class CreateConfiguration implements ServletOperation {
 
-        @Override public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
-                ResourceHandle resource) throws RepositoryException, IOException, ServletException {
+        @Override
+        public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
+                         ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -182,14 +198,15 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class CreateActivity implements ServletOperation {
 
-        @Override public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
-                ResourceHandle resource) throws RepositoryException, IOException, ServletException {
+        @Override
+        public void doIt(SlingHttpServletRequest request, SlingHttpServletResponse response,
+                         ResourceHandle resource) throws RepositoryException, IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
                 final String activity = AbstractServiceServlet.getPath(request);
                 final VersionManager versionManager = session.getWorkspace().getVersionManager();
-                versionManager.createActivity(activity.startsWith("/")?activity.substring(1):activity);
+                versionManager.createActivity(activity.startsWith("/") ? activity.substring(1) : activity);
                 ResponseUtil.writeEmptyArray(response);
             } catch (final RepositoryException ex) {
                 LOG.error(ex.getMessage(), ex);
@@ -199,8 +216,9 @@ public class VersionServlet extends AbstractServiceServlet {
     }
 
     public static class DeleteLabel implements ServletOperation {
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -222,8 +240,9 @@ public class VersionServlet extends AbstractServiceServlet {
     }
 
     public static class AddLabel implements ServletOperation {
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -245,8 +264,9 @@ public class VersionServlet extends AbstractServiceServlet {
     }
 
     public static class GetLabels implements ServletOperation {
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final Node node = resource.adaptTo(Node.class);
                 if (node == null) {
@@ -284,8 +304,9 @@ public class VersionServlet extends AbstractServiceServlet {
     }
 
     public static class GetVersions implements ServletOperation {
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final Node node = resource.adaptTo(Node.class);
                 if (node == null) {
@@ -341,8 +362,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class CheckoutOperation implements ServletOperation {
 
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -359,8 +381,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class CheckinOperation implements ServletOperation {
 
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);
@@ -377,8 +400,9 @@ public class VersionServlet extends AbstractServiceServlet {
 
     public static class CheckpointOperation implements ServletOperation {
 
-        @Override public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
-                final ResourceHandle resource) throws IOException, ServletException {
+        @Override
+        public void doIt(final SlingHttpServletRequest request, final SlingHttpServletResponse response,
+                         final ResourceHandle resource) throws IOException, ServletException {
             try {
                 final ResourceResolver resolver = request.getResourceResolver();
                 final JackrabbitSession session = (JackrabbitSession) resolver.adaptTo(Session.class);

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/PackageServlet.java
@@ -20,21 +20,14 @@ import com.google.gson.stream.JsonWriter;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
-import org.apache.jackrabbit.vault.fs.api.FilterSet;
-import org.apache.jackrabbit.vault.fs.api.ImportMode;
-import org.apache.jackrabbit.vault.fs.api.PathFilter;
-import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
-import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.api.*;
 import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.config.MetaInf;
 import org.apache.jackrabbit.vault.fs.filter.DefaultPathFilter;
-import org.apache.jackrabbit.vault.packaging.JcrPackage;
-import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
-import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
-import org.apache.jackrabbit.vault.packaging.PackageException;
-import org.apache.jackrabbit.vault.packaging.Packaging;
+import org.apache.jackrabbit.vault.packaging.*;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
@@ -56,34 +49,30 @@ import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
+import static com.composum.sling.core.pckgmgr.PackageServlet.SERVLET_PATH;
 
 /**
  * The servlet to provide download and upload of content packages and package definitions.
  */
 @SlingServlet(
-        paths = "/bin/cpm/package",
+        paths = SERVLET_PATH,
         methods = {"GET", "POST", "PUT", "DELETE"},
         metatype = true,
         label = "Composum PackageServlet")
+@Properties(value = {
+        @org.apache.felix.scr.annotations.Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class PackageServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(PackageServlet.class);
 
+    public static final String SERVLET_PATH = "/bin/cpm/package";
     public static final String PARAM_GROUP = "group";
     public static final String PARAM_FORCE = "force";
     private static final String PACKAGE_JOB_TIMEOUT = "package.job.timeout";

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
@@ -3,6 +3,8 @@ package com.composum.sling.core.pckgmgr.view;
 import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
@@ -17,6 +19,9 @@ import static com.composum.sling.core.pckgmgr.view.PackagesServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class PackagesServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/packages";

--- a/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
+++ b/sling/core/pckgmgr/src/main/java/com/composum/sling/core/pckgmgr/view/PackagesServlet.java
@@ -19,8 +19,8 @@ import static com.composum.sling.core.pckgmgr.view.PackagesServlet.SERVLET_PATH;
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
-@Properties(value={
-    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
 })
 public class PackagesServlet extends AbstractConsoleServlet {
 

--- a/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
+++ b/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
@@ -4,6 +4,9 @@ import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -17,6 +20,9 @@ import static com.composum.sling.core.usermanagement.UserManagerServlet.SERVLET_
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
+@Properties(value={
+    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+})
 public class UserManagerServlet extends AbstractConsoleServlet {
 
     public static final String SERVLET_PATH = "/bin/users";

--- a/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
+++ b/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/UserManagerServlet.java
@@ -3,10 +3,9 @@ package com.composum.sling.core.usermanagement;
 import com.composum.sling.core.BeanContext;
 import com.composum.sling.core.servlet.AbstractConsoleServlet;
 import com.composum.sling.nodes.NodesConfiguration;
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
-
+import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 
 import java.util.regex.Pattern;
@@ -20,8 +19,8 @@ import static com.composum.sling.core.usermanagement.UserManagerServlet.SERVLET_
         paths = SERVLET_PATH,
         methods = {"GET"}
 )
-@Properties(value={
-    @Property(name="sling.auth.requirements", value={ "+" + SERVLET_PATH })
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
 })
 public class UserManagerServlet extends AbstractConsoleServlet {
 

--- a/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/core/UserManagementServlet.java
+++ b/sling/core/usermgnt/src/main/java/com/composum/sling/core/usermanagement/core/UserManagementServlet.java
@@ -1,26 +1,23 @@
 package com.composum.sling.core.usermanagement.core;
 
-import com.composum.sling.core.util.XSS;
-import com.composum.sling.nodes.NodesConfiguration;
 import com.composum.sling.core.ResourceHandle;
 import com.composum.sling.core.mapping.MappingRules;
 import com.composum.sling.core.servlet.AbstractServiceServlet;
 import com.composum.sling.core.servlet.ServletOperation;
 import com.composum.sling.core.servlet.ServletOperationSet;
 import com.composum.sling.core.util.ResponseUtil;
+import com.composum.sling.core.util.XSS;
+import com.composum.sling.nodes.NodesConfiguration;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.jackrabbit.api.JackrabbitSession;
-import org.apache.jackrabbit.api.security.user.Authorizable;
-import org.apache.jackrabbit.api.security.user.Group;
-import org.apache.jackrabbit.api.security.user.Query;
-import org.apache.jackrabbit.api.security.user.QueryBuilder;
-import org.apache.jackrabbit.api.security.user.User;
-import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.jackrabbit.api.security.user.*;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -38,25 +35,26 @@ import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
+import static com.composum.sling.core.usermanagement.core.UserManagementServlet.SERVLET_PATH;
 
 /**
  * @author Mirko Zeibig
  * @since 26.10.2015
  */
 @SlingServlet(
-        paths = "/bin/cpm/usermanagement",
+        paths = SERVLET_PATH,
         methods = {"GET", "PUT", "POST", "DELETE"}
 )
+@Properties(value = {
+        @Property(name = "sling.auth.requirements", value = {"+" + SERVLET_PATH})
+})
 public class UserManagementServlet extends AbstractServiceServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(UserManagementServlet.class);
+
+    public static final String SERVLET_PATH = "/bin/cpm/usermanagement";
 
     public enum Extension {json, html}
 


### PR DESCRIPTION
This extends [this PR](https://github.com/ist-dresden/composum/pull/204) for issue #180 in that it instructs the Sling authenticator to prompt users for authentication on most servlets relevant for the console, so that the user is requested to login if necessary both when the browser requests a top level servlet, as well as when views are switched within the browser, package manager etc.

Rationale:
The sling.auth.requirements property of servlets modularizes the "Authentication Requirements" setting of the "Apache Sling Authentication Service", and is used here to specify some URLs for which a login needs to be triggered directly on each servlet. If Composum Platform is deployed, the "Authentication Requirements" are set to require login for everything below /bin, among others. Thus, an access to the browser, package manager and user manager toplevel servlets leads to a login by redirection to the login page, and if one of the internal views is switched on a logged out session, some javascript magic during the Ajax request displays a login dialog.

Not so when Composum Nodes (Core) is deployed without Composum Platform. If the Apache Sling Authentication Service is not configured manually to require authentication for them, a 403 is returned on session timeout for these top level servlets (set from their code), and the internal views get a 400, which is displayed as error message. This PR changes this as far as possible, so that this is handled properly.